### PR TITLE
Fix Vite version for Node 16 compatibility

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "^3.2.0",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
@@ -33,6 +33,6 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "vite": "^5.0.12"
+    "vite": "^4.5.2"
   }
 }


### PR DESCRIPTION
## Summary
- downgrade Vite to a Node 16 compatible release
- align the React plugin version with the Vite downgrade

## Testing
- npm install (fails: registry access restricted in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e15a519f1c8323a3de70807529661f