### PR TITLE
Stabilize Vite React setup for Node 16

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "3.1.0",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
@@ -33,6 +33,6 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "vite": "^5.0.12"
+    "vite": "^4.5.2"
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { webcrypto } from 'node:crypto';
+
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.getRandomValues !== 'function') {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true
+  });
+}
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- pin @vitejs/plugin-react to version 3.1.0 to avoid requesting a non-existent release when installing on Node 16
- polyfill global crypto access in vite.config.ts so Vite can call getRandomValues on older Node runtimes

## Testing
- npm install *(fails: registry access forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15a519f1c8323a3de70807529661f