### PR TITLE
Fix Flyway checksum regression for export permissions

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -115,6 +115,11 @@
             <version>1.19.7</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -130,6 +135,9 @@
                 <version>3.11.0</version>
                 <configuration>
                     <release>${java.version}</release>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/backend/src/main/java/com/example/rbac/auth/dto/AuthResponse.java
+++ b/backend/src/main/java/com/example/rbac/auth/dto/AuthResponse.java
@@ -10,6 +10,8 @@ public class AuthResponse {
     private UserDto user;
     private Set<String> roles;
     private Set<String> permissions;
+    private Set<String> directPermissions;
+    private Set<String> revokedPermissions;
 
     public String getAccessToken() {
         return accessToken;
@@ -49,5 +51,21 @@ public class AuthResponse {
 
     public void setPermissions(Set<String> permissions) {
         this.permissions = permissions;
+    }
+
+    public Set<String> getDirectPermissions() {
+        return directPermissions;
+    }
+
+    public void setDirectPermissions(Set<String> directPermissions) {
+        this.directPermissions = directPermissions;
+    }
+
+    public Set<String> getRevokedPermissions() {
+        return revokedPermissions;
+    }
+
+    public void setRevokedPermissions(Set<String> revokedPermissions) {
+        this.revokedPermissions = revokedPermissions;
     }
 }

--- a/backend/src/main/java/com/example/rbac/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/rbac/auth/service/AuthService.java
@@ -69,7 +69,6 @@ public class AuthService {
             throw new ApiException(HttpStatus.UNAUTHORIZED, "Invalid credentials");
         }
         User user = userRepository.findByEmail(request.getEmail())
-                .flatMap(u -> userRepository.findDetailedById(u.getId()))
                 .orElseThrow(() -> new ApiException(HttpStatus.UNAUTHORIZED, "User not found"));
         String refreshTokenValue = createRefreshToken(user);
         return buildAuthResponse(user, refreshTokenValue);
@@ -123,6 +122,8 @@ public class AuthService {
         response.setUser(userDto);
         response.setRoles(userDto.getRoles());
         response.setPermissions(userDto.getPermissions());
+        response.setDirectPermissions(userDto.getDirectPermissions());
+        response.setRevokedPermissions(userDto.getRevokedPermissions());
         return response;
     }
 }

--- a/backend/src/main/java/com/example/rbac/config/CorsProperties.java
+++ b/backend/src/main/java/com/example/rbac/config/CorsProperties.java
@@ -1,0 +1,25 @@
+package com.example.rbac.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@ConfigurationProperties(prefix = "app.cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins = new ArrayList<>(List.of(
+            "http://localhost:*",
+            "http://127.0.0.1:*"
+    ));
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/config/WebConfig.java
+++ b/backend/src/main/java/com/example/rbac/config/WebConfig.java
@@ -11,11 +11,17 @@ import java.util.List;
 @Configuration
 public class WebConfig {
 
+    private final CorsProperties corsProperties;
+
+    public WebConfig(CorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
+    }
+
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOriginPatterns(List.of("http://localhost:*"));
+        config.setAllowedOriginPatterns(corsProperties.getAllowedOrigins());
         config.setAllowedHeaders(List.of("*"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
 

--- a/backend/src/main/java/com/example/rbac/customers/controller/CustomerController.java
+++ b/backend/src/main/java/com/example/rbac/customers/controller/CustomerController.java
@@ -5,6 +5,7 @@ import com.example.rbac.customers.dto.CustomerDto;
 import com.example.rbac.customers.dto.CustomerRequest;
 import com.example.rbac.customers.service.CustomerService;
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,28 +19,33 @@ public class CustomerController {
     }
 
     @GetMapping
-    public PageResponse<CustomerDto> list(@RequestParam(defaultValue = "0") int page,
-                                          @RequestParam(defaultValue = "20") int size) {
+    @PreAuthorize("hasAuthority('CUSTOMER_VIEW')")
+    public PageResponse<CustomerDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                          @RequestParam(name = "size", defaultValue = "20") int size) {
         return customerService.list(page, size);
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('CUSTOMER_CREATE')")
     public CustomerDto create(@Valid @RequestBody CustomerRequest request) {
         return customerService.create(request);
     }
 
     @GetMapping("/{id}")
-    public CustomerDto get(@PathVariable Long id) {
+    @PreAuthorize("hasAuthority('CUSTOMER_VIEW')")
+    public CustomerDto get(@PathVariable("id") Long id) {
         return customerService.get(id);
     }
 
     @PutMapping("/{id}")
-    public CustomerDto update(@PathVariable Long id, @Valid @RequestBody CustomerRequest request) {
+    @PreAuthorize("hasAuthority('CUSTOMER_UPDATE')")
+    public CustomerDto update(@PathVariable("id") Long id, @Valid @RequestBody CustomerRequest request) {
         return customerService.update(id, request);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    @PreAuthorize("hasAuthority('CUSTOMER_DELETE')")
+    public void delete(@PathVariable("id") Long id) {
         customerService.delete(id);
     }
 }

--- a/backend/src/main/java/com/example/rbac/invoices/controller/InvoiceController.java
+++ b/backend/src/main/java/com/example/rbac/invoices/controller/InvoiceController.java
@@ -5,6 +5,7 @@ import com.example.rbac.invoices.dto.InvoiceDto;
 import com.example.rbac.invoices.dto.InvoiceRequest;
 import com.example.rbac.invoices.service.InvoiceService;
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,28 +19,33 @@ public class InvoiceController {
     }
 
     @GetMapping
-    public PageResponse<InvoiceDto> list(@RequestParam(defaultValue = "0") int page,
-                                         @RequestParam(defaultValue = "20") int size) {
+    @PreAuthorize("hasAuthority('INVOICE_VIEW')")
+    public PageResponse<InvoiceDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                         @RequestParam(name = "size", defaultValue = "20") int size) {
         return invoiceService.list(page, size);
     }
 
     @PostMapping
+    @PreAuthorize("hasAuthority('INVOICE_CREATE')")
     public InvoiceDto create(@Valid @RequestBody InvoiceRequest request) {
         return invoiceService.create(request);
     }
 
     @GetMapping("/{id}")
-    public InvoiceDto get(@PathVariable Long id) {
+    @PreAuthorize("hasAuthority('INVOICE_VIEW')")
+    public InvoiceDto get(@PathVariable("id") Long id) {
         return invoiceService.get(id);
     }
 
     @PutMapping("/{id}")
-    public InvoiceDto update(@PathVariable Long id, @Valid @RequestBody InvoiceRequest request) {
+    @PreAuthorize("hasAuthority('INVOICE_UPDATE')")
+    public InvoiceDto update(@PathVariable("id") Long id, @Valid @RequestBody InvoiceRequest request) {
         return invoiceService.update(id, request);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    @PreAuthorize("hasAuthority('INVOICE_DELETE')")
+    public void delete(@PathVariable("id") Long id) {
         invoiceService.delete(id);
     }
 }

--- a/backend/src/main/java/com/example/rbac/permissions/controller/PermissionController.java
+++ b/backend/src/main/java/com/example/rbac/permissions/controller/PermissionController.java
@@ -18,9 +18,11 @@ public class PermissionController {
     }
 
     @GetMapping
-    public PageResponse<PermissionDto> list(@RequestParam(defaultValue = "0") int page,
-                                            @RequestParam(defaultValue = "20") int size) {
-        return permissionService.list(page, size);
+    public PageResponse<PermissionDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                            @RequestParam(name = "size", defaultValue = "20") int size,
+                                            @RequestParam(name = "sort", defaultValue = "key") String sort,
+                                            @RequestParam(name = "direction", defaultValue = "asc") String direction) {
+        return permissionService.list(page, size, sort, direction);
     }
 
     @PostMapping
@@ -29,12 +31,12 @@ public class PermissionController {
     }
 
     @PutMapping("/{id}")
-    public PermissionDto update(@PathVariable Long id, @Valid @RequestBody PermissionRequest request) {
+    public PermissionDto update(@PathVariable("id") Long id, @Valid @RequestBody PermissionRequest request) {
         return permissionService.update(id, request);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable("id") Long id) {
         permissionService.delete(id);
     }
 }

--- a/backend/src/main/java/com/example/rbac/permissions/repository/PermissionRepository.java
+++ b/backend/src/main/java/com/example/rbac/permissions/repository/PermissionRepository.java
@@ -3,8 +3,12 @@ package com.example.rbac.permissions.repository;
 import com.example.rbac.permissions.model.Permission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface PermissionRepository extends JpaRepository<Permission, Long> {
     Optional<Permission> findByKey(String key);
+
+    List<Permission> findByKeyIn(Set<String> keys);
 }

--- a/backend/src/main/java/com/example/rbac/permissions/service/PermissionService.java
+++ b/backend/src/main/java/com/example/rbac/permissions/service/PermissionService.java
@@ -10,6 +10,7 @@ import com.example.rbac.permissions.repository.PermissionRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
@@ -27,10 +28,22 @@ public class PermissionService {
     }
 
     @PreAuthorize("hasAuthority('PERMISSION_VIEW')")
-    public PageResponse<PermissionDto> list(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+    public PageResponse<PermissionDto> list(int page, int size, String sort, String direction) {
+        Pageable pageable = buildPageable(page, size, sort, direction);
         Page<PermissionDto> result = permissionRepository.findAll(pageable).map(permissionMapper::toDto);
         return PageResponse.from(result);
+    }
+
+    private Pageable buildPageable(int page, int size, String sort, String direction) {
+        String normalizedSort = sort == null ? "key" : sort.toLowerCase();
+        String property;
+        switch (normalizedSort) {
+            case "name" -> property = "name";
+            case "createdat" -> property = "createdAt";
+            default -> property = "key";
+        }
+        Sort.Direction sortDirection = "desc".equalsIgnoreCase(direction) ? Sort.Direction.DESC : Sort.Direction.ASC;
+        return PageRequest.of(page, size, Sort.by(sortDirection, property));
     }
 
     @PreAuthorize("hasAuthority('PERMISSION_CREATE')")

--- a/backend/src/main/java/com/example/rbac/roles/controller/RoleController.java
+++ b/backend/src/main/java/com/example/rbac/roles/controller/RoleController.java
@@ -19,9 +19,11 @@ public class RoleController {
     }
 
     @GetMapping
-    public PageResponse<RoleDto> list(@RequestParam(defaultValue = "0") int page,
-                                      @RequestParam(defaultValue = "20") int size) {
-        return roleService.list(page, size);
+    public PageResponse<RoleDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                      @RequestParam(name = "size", defaultValue = "20") int size,
+                                      @RequestParam(name = "sort", defaultValue = "name") String sort,
+                                      @RequestParam(name = "direction", defaultValue = "asc") String direction) {
+        return roleService.list(page, size, sort, direction);
     }
 
     @PostMapping
@@ -30,27 +32,27 @@ public class RoleController {
     }
 
     @GetMapping("/{id}")
-    public RoleDto get(@PathVariable Long id) {
+    public RoleDto get(@PathVariable("id") Long id) {
         return roleService.get(id);
     }
 
     @PutMapping("/{id}")
-    public RoleDto update(@PathVariable Long id, @Valid @RequestBody RoleRequest request) {
+    public RoleDto update(@PathVariable("id") Long id, @Valid @RequestBody RoleRequest request) {
         return roleService.update(id, request);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable("id") Long id) {
         roleService.delete(id);
     }
 
     @PostMapping("/{id}/permissions")
-    public RoleDto assignPermissions(@PathVariable Long id, @Valid @RequestBody AssignPermissionsRequest request) {
+    public RoleDto assignPermissions(@PathVariable("id") Long id, @Valid @RequestBody AssignPermissionsRequest request) {
         return roleService.assignPermissions(id, request);
     }
 
     @DeleteMapping("/{id}/permissions/{permissionId}")
-    public RoleDto removePermission(@PathVariable Long id, @PathVariable Long permissionId) {
+    public RoleDto removePermission(@PathVariable("id") Long id, @PathVariable("permissionId") Long permissionId) {
         return roleService.removePermission(id, permissionId);
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/controller/UserController.java
+++ b/backend/src/main/java/com/example/rbac/users/controller/UserController.java
@@ -4,7 +4,10 @@ import com.example.rbac.common.pagination.PageResponse;
 import com.example.rbac.users.dto.AssignRolesRequest;
 import com.example.rbac.users.dto.CreateUserRequest;
 import com.example.rbac.users.dto.UpdateUserRequest;
+import com.example.rbac.users.dto.UpdateUserPermissionsRequest;
 import com.example.rbac.users.dto.UserDto;
+import com.example.rbac.users.dto.UserSummaryResponse;
+import com.example.rbac.users.dto.UpdateUserStatusRequest;
 import com.example.rbac.users.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
@@ -20,10 +23,17 @@ public class UserController {
     }
 
     @GetMapping
-    public PageResponse<UserDto> list(@RequestParam(required = false) String search,
-                                      @RequestParam(defaultValue = "0") int page,
-                                      @RequestParam(defaultValue = "20") int size) {
-        return userService.list(search, page, size);
+    public PageResponse<UserDto> list(@RequestParam(name = "search", required = false) String search,
+                                      @RequestParam(name = "page", defaultValue = "0") int page,
+                                      @RequestParam(name = "size", defaultValue = "20") int size,
+                                      @RequestParam(name = "sort", defaultValue = "name") String sort,
+                                      @RequestParam(name = "direction", defaultValue = "asc") String direction) {
+        return userService.list(search, page, size, sort, direction);
+    }
+
+    @GetMapping("/summary")
+    public UserSummaryResponse summary() {
+        return userService.summary();
     }
 
     @PostMapping
@@ -32,27 +42,39 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
-    public UserDto get(@PathVariable Long id) {
+    public UserDto get(@PathVariable("id") Long id) {
         return userService.get(id);
     }
 
     @PutMapping("/{id}")
-    public UserDto update(@PathVariable Long id, @Valid @RequestBody UpdateUserRequest request) {
+    public UserDto update(@PathVariable("id") Long id, @Valid @RequestBody UpdateUserRequest request) {
         return userService.update(id, request);
     }
 
+    @PatchMapping("/{id}/status")
+    public UserDto updateStatus(@PathVariable("id") Long id,
+                                @Valid @RequestBody UpdateUserStatusRequest request) {
+        return userService.updateStatus(id, request);
+    }
+
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    public void delete(@PathVariable("id") Long id) {
         userService.delete(id);
     }
 
     @PostMapping("/{id}/roles")
-    public UserDto assignRoles(@PathVariable Long id, @Valid @RequestBody AssignRolesRequest request) {
+    public UserDto assignRoles(@PathVariable("id") Long id, @Valid @RequestBody AssignRolesRequest request) {
         return userService.assignRoles(id, request);
     }
 
     @DeleteMapping("/{userId}/roles/{roleId}")
-    public UserDto removeRole(@PathVariable Long userId, @PathVariable Long roleId) {
+    public UserDto removeRole(@PathVariable("userId") Long userId, @PathVariable("roleId") Long roleId) {
         return userService.removeRole(userId, roleId);
+    }
+
+    @PutMapping("/{id}/permissions")
+    public UserDto updatePermissions(@PathVariable("id") Long id,
+                                     @Valid @RequestBody UpdateUserPermissionsRequest request) {
+        return userService.updateDirectPermissions(id, request);
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/dto/CreateUserRequest.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/CreateUserRequest.java
@@ -22,6 +22,10 @@ public class CreateUserRequest {
 
     private Set<Long> roleIds;
 
+    private Set<String> permissionKeys;
+
+    private Set<String> revokedPermissionKeys;
+
     public String getEmail() {
         return email;
     }
@@ -60,5 +64,21 @@ public class CreateUserRequest {
 
     public void setRoleIds(Set<Long> roleIds) {
         this.roleIds = roleIds;
+    }
+
+    public Set<String> getPermissionKeys() {
+        return permissionKeys;
+    }
+
+    public void setPermissionKeys(Set<String> permissionKeys) {
+        this.permissionKeys = permissionKeys;
+    }
+
+    public Set<String> getRevokedPermissionKeys() {
+        return revokedPermissionKeys;
+    }
+
+    public void setRevokedPermissionKeys(Set<String> revokedPermissionKeys) {
+        this.revokedPermissionKeys = revokedPermissionKeys;
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/dto/UpdateUserPermissionsRequest.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/UpdateUserPermissionsRequest.java
@@ -1,0 +1,30 @@
+package com.example.rbac.users.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Set;
+
+public class UpdateUserPermissionsRequest {
+
+    @NotNull
+    private Set<String> grantedPermissionKeys;
+
+    @NotNull
+    private Set<String> revokedPermissionKeys;
+
+    public Set<String> getGrantedPermissionKeys() {
+        return grantedPermissionKeys;
+    }
+
+    public void setGrantedPermissionKeys(Set<String> grantedPermissionKeys) {
+        this.grantedPermissionKeys = grantedPermissionKeys;
+    }
+
+    public Set<String> getRevokedPermissionKeys() {
+        return revokedPermissionKeys;
+    }
+
+    public void setRevokedPermissionKeys(Set<String> revokedPermissionKeys) {
+        this.revokedPermissionKeys = revokedPermissionKeys;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/users/dto/UpdateUserRequest.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/UpdateUserRequest.java
@@ -21,6 +21,10 @@ public class UpdateUserRequest {
 
     private Set<Long> roleIds;
 
+    private Set<String> permissionKeys;
+
+    private Set<String> revokedPermissionKeys;
+
     public String getEmail() {
         return email;
     }
@@ -59,5 +63,21 @@ public class UpdateUserRequest {
 
     public void setRoleIds(Set<Long> roleIds) {
         this.roleIds = roleIds;
+    }
+
+    public Set<String> getPermissionKeys() {
+        return permissionKeys;
+    }
+
+    public void setPermissionKeys(Set<String> permissionKeys) {
+        this.permissionKeys = permissionKeys;
+    }
+
+    public Set<String> getRevokedPermissionKeys() {
+        return revokedPermissionKeys;
+    }
+
+    public void setRevokedPermissionKeys(Set<String> revokedPermissionKeys) {
+        this.revokedPermissionKeys = revokedPermissionKeys;
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/dto/UpdateUserStatusRequest.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/UpdateUserStatusRequest.java
@@ -1,0 +1,17 @@
+package com.example.rbac.users.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public class UpdateUserStatusRequest {
+
+    @NotNull
+    private Boolean active;
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/users/dto/UserDto.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/UserDto.java
@@ -10,6 +10,8 @@ public class UserDto {
     private boolean active;
     private Set<String> roles;
     private Set<String> permissions;
+    private Set<String> directPermissions;
+    private Set<String> revokedPermissions;
     private Instant createdAt;
     private Instant updatedAt;
 
@@ -59,6 +61,22 @@ public class UserDto {
 
     public void setPermissions(Set<String> permissions) {
         this.permissions = permissions;
+    }
+
+    public Set<String> getDirectPermissions() {
+        return directPermissions;
+    }
+
+    public void setDirectPermissions(Set<String> directPermissions) {
+        this.directPermissions = directPermissions;
+    }
+
+    public Set<String> getRevokedPermissions() {
+        return revokedPermissions;
+    }
+
+    public void setRevokedPermissions(Set<String> revokedPermissions) {
+        this.revokedPermissions = revokedPermissions;
     }
 
     public Instant getCreatedAt() {

--- a/backend/src/main/java/com/example/rbac/users/dto/UserSummaryResponse.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/UserSummaryResponse.java
@@ -1,0 +1,61 @@
+package com.example.rbac.users.dto;
+
+public class UserSummaryResponse {
+    private long totalUsers;
+    private long activeUsers;
+    private long inactiveUsers;
+    private long customerUsers;
+    private long internalUsers;
+
+    public UserSummaryResponse(long totalUsers,
+                               long activeUsers,
+                               long inactiveUsers,
+                               long customerUsers,
+                               long internalUsers) {
+        this.totalUsers = totalUsers;
+        this.activeUsers = activeUsers;
+        this.inactiveUsers = inactiveUsers;
+        this.customerUsers = customerUsers;
+        this.internalUsers = internalUsers;
+    }
+
+    public long getTotalUsers() {
+        return totalUsers;
+    }
+
+    public void setTotalUsers(long totalUsers) {
+        this.totalUsers = totalUsers;
+    }
+
+    public long getActiveUsers() {
+        return activeUsers;
+    }
+
+    public void setActiveUsers(long activeUsers) {
+        this.activeUsers = activeUsers;
+    }
+
+    public long getInactiveUsers() {
+        return inactiveUsers;
+    }
+
+    public void setInactiveUsers(long inactiveUsers) {
+        this.inactiveUsers = inactiveUsers;
+    }
+
+    public long getCustomerUsers() {
+        return customerUsers;
+    }
+
+    public void setCustomerUsers(long customerUsers) {
+        this.customerUsers = customerUsers;
+    }
+
+    public long getInternalUsers() {
+        return internalUsers;
+    }
+
+    public void setInternalUsers(long internalUsers) {
+        this.internalUsers = internalUsers;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/users/mapper/UserMapper.java
+++ b/backend/src/main/java/com/example/rbac/users/mapper/UserMapper.java
@@ -12,16 +12,33 @@ import java.util.stream.Collectors;
 public interface UserMapper {
 
     @Mapping(target = "roles", expression = "java(extractRoleKeys(user))")
-    @Mapping(target = "permissions", expression = "java(extractPermissions(user))")
+    @Mapping(target = "permissions", expression = "java(extractAllPermissions(user))")
+    @Mapping(target = "directPermissions", expression = "java(extractDirectPermissions(user))")
+    @Mapping(target = "revokedPermissions", expression = "java(extractRevokedPermissions(user))")
     UserDto toDto(User user);
 
     default Set<String> extractRoleKeys(User user) {
         return user.getRoles().stream().map(role -> role.getKey()).collect(Collectors.toSet());
     }
 
-    default Set<String> extractPermissions(User user) {
-        return user.getRoles().stream()
+    default Set<String> extractAllPermissions(User user) {
+        Set<String> permissions = user.getRoles().stream()
                 .flatMap(role -> role.getPermissions().stream())
+                .map(permission -> permission.getKey())
+                .collect(Collectors.toSet());
+        permissions.addAll(extractDirectPermissions(user));
+        permissions.removeAll(extractRevokedPermissions(user));
+        return permissions;
+    }
+
+    default Set<String> extractDirectPermissions(User user) {
+        return user.getDirectPermissions().stream()
+                .map(permission -> permission.getKey())
+                .collect(Collectors.toSet());
+    }
+
+    default Set<String> extractRevokedPermissions(User user) {
+        return user.getRevokedPermissions().stream()
                 .map(permission -> permission.getKey())
                 .collect(Collectors.toSet());
     }

--- a/backend/src/main/java/com/example/rbac/users/model/User.java
+++ b/backend/src/main/java/com/example/rbac/users/model/User.java
@@ -1,6 +1,7 @@
 package com.example.rbac.users.model;
 
 import com.example.rbac.roles.model.Role;
+import com.example.rbac.permissions.model.Permission;
 import com.example.rbac.auth.token.RefreshToken;
 import jakarta.persistence.*;
 import java.time.Instant;
@@ -32,6 +33,18 @@ public class User {
             joinColumns = @JoinColumn(name = "user_id"),
             inverseJoinColumns = @JoinColumn(name = "role_id"))
     private Set<Role> roles = new HashSet<>();
+
+    @ManyToMany
+    @JoinTable(name = "user_permission_overrides",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "permission_id"))
+    private Set<Permission> directPermissions = new HashSet<>();
+
+    @ManyToMany
+    @JoinTable(name = "user_permission_revocations",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "permission_id"))
+    private Set<Permission> revokedPermissions = new HashSet<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<RefreshToken> refreshTokens = new HashSet<>();
@@ -100,6 +113,22 @@ public class User {
 
     public void setRoles(Set<Role> roles) {
         this.roles = roles;
+    }
+
+    public Set<Permission> getDirectPermissions() {
+        return directPermissions;
+    }
+
+    public void setDirectPermissions(Set<Permission> directPermissions) {
+        this.directPermissions = directPermissions;
+    }
+
+    public Set<Permission> getRevokedPermissions() {
+        return revokedPermissions;
+    }
+
+    public void setRevokedPermissions(Set<Permission> revokedPermissions) {
+        this.revokedPermissions = revokedPermissions;
     }
 
     public Set<RefreshToken> getRefreshTokens() {

--- a/backend/src/main/java/com/example/rbac/users/model/UserPrincipal.java
+++ b/backend/src/main/java/com/example/rbac/users/model/UserPrincipal.java
@@ -27,6 +27,13 @@ public class UserPrincipal implements UserDetails {
                 .flatMap(role -> role.getPermissions().stream())
                 .map(permission -> permission.getKey())
                 .collect(Collectors.toSet());
+        perms.addAll(user.getDirectPermissions().stream()
+                .map(permission -> permission.getKey())
+                .collect(Collectors.toSet()));
+        Set<String> revoked = user.getRevokedPermissions().stream()
+                .map(permission -> permission.getKey())
+                .collect(Collectors.toSet());
+        perms.removeAll(revoked);
         return perms.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
     }
 

--- a/backend/src/main/java/com/example/rbac/users/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/rbac/users/repository/UserRepository.java
@@ -5,19 +5,29 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    @EntityGraph(attributePaths = {"roles", "roles.permissions", "directPermissions", "revokedPermissions"})
     Optional<User> findByEmail(String email);
 
-    @EntityGraph(attributePaths = {"roles", "roles.permissions"})
+    @EntityGraph(attributePaths = {"roles", "roles.permissions", "directPermissions", "revokedPermissions"})
     Optional<User> findDetailedById(Long id);
 
-    @EntityGraph(attributePaths = {"roles", "roles.permissions"})
+    @EntityGraph(attributePaths = {"roles", "roles.permissions", "directPermissions", "revokedPermissions"})
     Page<User> findByEmailContainingIgnoreCaseOrFullNameContainingIgnoreCase(String email, String name, Pageable pageable);
 
     @Override
-    @EntityGraph(attributePaths = {"roles", "roles.permissions"})
+    @EntityGraph(attributePaths = {"roles", "roles.permissions", "directPermissions", "revokedPermissions"})
     Page<User> findAll(Pageable pageable);
+
+    long countByActiveTrue();
+
+    long countByActiveFalse();
+
+    @Query("SELECT COUNT(DISTINCT u) FROM User u JOIN u.roles r WHERE UPPER(r.key) = UPPER(:roleKey)")
+    long countByRoleKeyIgnoreCase(@Param("roleKey") String roleKey);
 }

--- a/backend/src/main/java/com/example/rbac/users/service/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/example/rbac/users/service/UserDetailsServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserDetailsServiceImpl implements UserDetailsService {
@@ -18,11 +19,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-        user.getRoles().size();
-        user.getRoles().forEach(role -> role.getPermissions().size());
         return new UserPrincipal(user);
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/service/UserService.java
+++ b/backend/src/main/java/com/example/rbac/users/service/UserService.java
@@ -4,11 +4,16 @@ import com.example.rbac.common.exception.ApiException;
 import com.example.rbac.common.pagination.PageResponse;
 import com.example.rbac.roles.model.Role;
 import com.example.rbac.roles.repository.RoleRepository;
+import com.example.rbac.permissions.model.Permission;
+import com.example.rbac.permissions.repository.PermissionRepository;
 import com.example.rbac.users.dto.AssignRolesRequest;
 import com.example.rbac.users.dto.CreateUserRequest;
 import com.example.rbac.users.dto.ProfileUpdateRequest;
 import com.example.rbac.users.dto.UpdateUserRequest;
+import com.example.rbac.users.dto.UpdateUserPermissionsRequest;
+import com.example.rbac.users.dto.UpdateUserStatusRequest;
 import com.example.rbac.users.dto.UserDto;
+import com.example.rbac.users.dto.UserSummaryResponse;
 import com.example.rbac.users.mapper.UserMapper;
 import com.example.rbac.users.model.User;
 import com.example.rbac.users.repository.UserRepository;
@@ -16,35 +21,56 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class UserService {
 
+    private static final String CUSTOMER_ROLE_KEY = "CUSTOMER";
+
+    private static final String USER_OR_CUSTOMER_VIEW = "hasAnyAuthority('USER_VIEW','USER_VIEW_GLOBAL','USER_VIEW_OWN','CUSTOMER_VIEW','CUSTOMER_VIEW_GLOBAL','CUSTOMER_VIEW_OWN','CUSTOMER_CREATE','CUSTOMER_UPDATE','CUSTOMER_DELETE')";
+    private static final String USER_OR_CUSTOMER_CREATE = "hasAnyAuthority('USER_CREATE','CUSTOMER_CREATE')";
+    private static final String USER_OR_CUSTOMER_UPDATE = "hasAnyAuthority('USER_UPDATE','CUSTOMER_UPDATE')";
+    private static final String USER_OR_CUSTOMER_DELETE = "hasAnyAuthority('USER_DELETE','CUSTOMER_DELETE')";
+
+    private static final Map<String, String> USER_SORT_MAPPING = Map.of(
+            "name", "fullName",
+            "email", "email",
+            "status", "active",
+            "createdAt", "createdAt"
+    );
+
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
+    private final PermissionRepository permissionRepository;
     private final UserMapper userMapper;
 
     public UserService(UserRepository userRepository,
                        RoleRepository roleRepository,
                        PasswordEncoder passwordEncoder,
+                       PermissionRepository permissionRepository,
                        UserMapper userMapper) {
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.passwordEncoder = passwordEncoder;
+        this.permissionRepository = permissionRepository;
         this.userMapper = userMapper;
     }
 
-    @PreAuthorize("hasAuthority('USER_VIEW')")
-    public PageResponse<UserDto> list(String search, int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+    @PreAuthorize(USER_OR_CUSTOMER_VIEW)
+    public PageResponse<UserDto> list(String search, int page, int size, String sort, String direction) {
+        Pageable pageable = buildPageable(page, size, sort, direction);
         Page<User> result;
         if (search != null && !search.isBlank()) {
             result = userRepository.findByEmailContainingIgnoreCaseOrFullNameContainingIgnoreCase(search, search, pageable);
@@ -54,7 +80,14 @@ public class UserService {
         return PageResponse.from(result.map(userMapper::toDto));
     }
 
-    @PreAuthorize("hasAuthority('USER_CREATE')")
+    private Pageable buildPageable(int page, int size, String sort, String direction) {
+        String normalizedSort = sort == null ? "name" : sort.toLowerCase();
+        String property = USER_SORT_MAPPING.getOrDefault(normalizedSort, USER_SORT_MAPPING.get("name"));
+        Sort.Direction sortDirection = "desc".equalsIgnoreCase(direction) ? Sort.Direction.DESC : Sort.Direction.ASC;
+        return PageRequest.of(page, size, Sort.by(sortDirection, property));
+    }
+
+    @PreAuthorize(USER_OR_CUSTOMER_CREATE)
     @Transactional
     public UserDto create(CreateUserRequest request) {
         userRepository.findByEmail(request.getEmail()).ifPresent(existing -> {
@@ -72,21 +105,26 @@ public class UserService {
             }
             user.setRoles(roles);
         }
+        Set<Permission> direct = fetchPermissions(request.getPermissionKeys());
+        user.setDirectPermissions(direct);
+        Set<Permission> revoked = fetchPermissions(request.getRevokedPermissionKeys());
+        removeOverlap(direct, revoked);
+        user.setRevokedPermissions(revoked);
         user = userRepository.save(user);
-        return userMapper.toDto(user);
+        return userMapper.toDto(userRepository.findDetailedById(user.getId()).orElseThrow());
     }
 
-    @PreAuthorize("hasAuthority('USER_VIEW')")
+    @PreAuthorize(USER_OR_CUSTOMER_VIEW)
     public UserDto get(Long id) {
         User user = userRepository.findDetailedById(id)
                 .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "User not found"));
         return userMapper.toDto(user);
     }
 
-    @PreAuthorize("hasAuthority('USER_UPDATE')")
+    @PreAuthorize(USER_OR_CUSTOMER_UPDATE)
     @Transactional
     public UserDto update(Long id, UpdateUserRequest request) {
-        User user = userRepository.findById(id)
+        User user = userRepository.findDetailedById(id)
                 .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "User not found"));
         user.setEmail(request.getEmail());
         user.setFullName(request.getFullName());
@@ -96,13 +134,38 @@ public class UserService {
         }
         if (request.getRoleIds() != null) {
             Set<Role> roles = new HashSet<>(roleRepository.findAllById(request.getRoleIds()));
+            if (roles.size() != request.getRoleIds().size()) {
+                throw new ApiException(HttpStatus.BAD_REQUEST, "One or more roles not found");
+            }
             user.setRoles(roles);
+        }
+        if (request.getPermissionKeys() != null) {
+            Set<Permission> direct = fetchPermissions(request.getPermissionKeys());
+            user.setDirectPermissions(direct);
+            Set<Permission> revoked = fetchPermissions(request.getRevokedPermissionKeys());
+            removeOverlap(direct, revoked);
+            user.setRevokedPermissions(revoked);
+        }
+        if (request.getRevokedPermissionKeys() != null && request.getPermissionKeys() == null) {
+            Set<Permission> revoked = fetchPermissions(request.getRevokedPermissionKeys());
+            removeOverlap(user.getDirectPermissions(), revoked);
+            user.setRevokedPermissions(revoked);
         }
         user = userRepository.save(user);
         return userMapper.toDto(userRepository.findDetailedById(user.getId()).orElseThrow());
     }
 
-    @PreAuthorize("hasAuthority('USER_DELETE')")
+    @PreAuthorize(USER_OR_CUSTOMER_UPDATE)
+    @Transactional
+    public UserDto updateStatus(Long id, UpdateUserStatusRequest request) {
+        User user = userRepository.findDetailedById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "User not found"));
+        user.setActive(Boolean.TRUE.equals(request.getActive()));
+        user = userRepository.save(user);
+        return userMapper.toDto(userRepository.findDetailedById(user.getId()).orElseThrow());
+    }
+
+    @PreAuthorize(USER_OR_CUSTOMER_DELETE)
     public void delete(Long id) {
         if (!userRepository.existsById(id)) {
             throw new ApiException(HttpStatus.NOT_FOUND, "User not found");
@@ -110,7 +173,7 @@ public class UserService {
         userRepository.deleteById(id);
     }
 
-    @PreAuthorize("hasAuthority('USER_UPDATE')")
+    @PreAuthorize(USER_OR_CUSTOMER_UPDATE)
     @Transactional
     public UserDto assignRoles(Long id, AssignRolesRequest request) {
         User user = userRepository.findDetailedById(id)
@@ -121,17 +184,17 @@ public class UserService {
         }
         user.setRoles(roles);
         user = userRepository.save(user);
-        return userMapper.toDto(user);
+        return userMapper.toDto(userRepository.findDetailedById(user.getId()).orElseThrow());
     }
 
-    @PreAuthorize("hasAuthority('USER_UPDATE')")
+    @PreAuthorize(USER_OR_CUSTOMER_UPDATE)
     @Transactional
     public UserDto removeRole(Long userId, Long roleId) {
         User user = userRepository.findDetailedById(userId)
                 .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "User not found"));
         user.getRoles().removeIf(role -> role.getId().equals(roleId));
         user = userRepository.save(user);
-        return userMapper.toDto(user);
+        return userMapper.toDto(userRepository.findDetailedById(user.getId()).orElseThrow());
     }
 
     @Transactional
@@ -144,5 +207,57 @@ public class UserService {
         }
         user = userRepository.save(user);
         return userMapper.toDto(user);
+    }
+
+    @PreAuthorize(USER_OR_CUSTOMER_UPDATE)
+    @Transactional
+    public UserDto updateDirectPermissions(Long id, UpdateUserPermissionsRequest request) {
+        User user = userRepository.findDetailedById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "User not found"));
+        Set<Permission> direct = fetchPermissions(request.getGrantedPermissionKeys());
+        Set<Permission> revoked = fetchPermissions(request.getRevokedPermissionKeys());
+        removeOverlap(direct, revoked);
+        user.setDirectPermissions(direct);
+        user.setRevokedPermissions(revoked);
+        user = userRepository.save(user);
+        return userMapper.toDto(userRepository.findDetailedById(user.getId()).orElseThrow());
+    }
+
+    @PreAuthorize(USER_OR_CUSTOMER_VIEW)
+    public UserSummaryResponse summary() {
+        long total = userRepository.count();
+        long active = userRepository.countByActiveTrue();
+        long inactive = userRepository.countByActiveFalse();
+        long customers = userRepository.countByRoleKeyIgnoreCase(CUSTOMER_ROLE_KEY);
+        long internal = Math.max(total - customers, 0);
+        return new UserSummaryResponse(total, active, inactive, customers, internal);
+    }
+
+    private Set<Permission> fetchPermissions(Set<String> permissionKeys) {
+        if (permissionKeys == null || permissionKeys.isEmpty()) {
+            return new HashSet<>();
+        }
+        Set<String> normalized = permissionKeys.stream()
+                .filter(key -> key != null && !key.isBlank())
+                .map(key -> key.toUpperCase())
+                .collect(Collectors.toCollection(HashSet::new));
+        if (normalized.isEmpty()) {
+            return new HashSet<>();
+        }
+        List<Permission> permissions = permissionRepository.findByKeyIn(normalized);
+        if (permissions.size() != normalized.size()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "One or more permissions were not found");
+        }
+        return new HashSet<>(permissions);
+    }
+
+    private void removeOverlap(Set<Permission> direct, Set<Permission> revoked) {
+        if (direct.isEmpty() || revoked.isEmpty()) {
+            return;
+        }
+        Set<String> directKeys = direct.stream()
+                .map(Permission::getKey)
+                .collect(Collectors.toSet());
+        revoked.removeIf(permission -> directKeys.contains(permission.getKey()));
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,6 +27,11 @@ app:
     secret: V1RY9m0xL8U7Q2pX5s6d8f1g2h3j4k5l6m7n8o9p0q1r2s3t4u5v6w7x8y9z0a
     access-token-ttl-seconds: 900
     refresh-token-ttl-seconds: 604800
+  cors:
+    allowed-origins:
+      - http://localhost:*
+      - http://127.0.0.1:*
+      - http://0.0.0.0:*
 
 springdoc:
   swagger-ui:

--- a/backend/src/main/resources/db/migration/V3__user_permission_overrides.sql
+++ b/backend/src/main/resources/db/migration/V3__user_permission_overrides.sql
@@ -1,0 +1,7 @@
+CREATE TABLE user_permission_overrides (
+    user_id BIGINT NOT NULL,
+    permission_id BIGINT NOT NULL,
+    PRIMARY KEY (user_id, permission_id),
+    CONSTRAINT fk_user_permission_overrides_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_permission_overrides_permission FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE CASCADE
+) ENGINE=InnoDB;

--- a/backend/src/main/resources/db/migration/V4__user_permission_revocations.sql
+++ b/backend/src/main/resources/db/migration/V4__user_permission_revocations.sql
@@ -1,0 +1,7 @@
+CREATE TABLE user_permission_revocations (
+    user_id BIGINT NOT NULL,
+    permission_id BIGINT NOT NULL,
+    PRIMARY KEY (user_id, permission_id),
+    CONSTRAINT fk_user_permission_revocations_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_permission_revocations_permission FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE CASCADE
+);

--- a/backend/src/main/resources/db/migration/V5__add_export_permissions.sql
+++ b/backend/src/main/resources/db/migration/V5__add_export_permissions.sql
@@ -1,0 +1,5 @@
+INSERT IGNORE INTO permissions (code, name) VALUES
+ ('USERS_EXPORT', 'Export Users'),
+ ('ROLES_EXPORT', 'Export Roles'),
+ ('PERMISSIONS_EXPORT', 'Export Permissions'),
+ ('INVOICES_EXPORT', 'Export Invoices');

--- a/backend/src/test/java/com/example/rbac/auth/AuthIntegrationTest.java
+++ b/backend/src/test/java/com/example/rbac/auth/AuthIntegrationTest.java
@@ -1,0 +1,71 @@
+package com.example.rbac.auth;
+
+import com.example.rbac.auth.dto.AuthResponse;
+import com.example.rbac.auth.dto.LoginRequest;
+import com.example.rbac.users.dto.UserDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class AuthIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void superAdminCanLoginAndAccessProtectedResources() {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("superadmin@demo.io");
+        request.setPassword("Super@123");
+
+        ResponseEntity<AuthResponse> loginResponse = restTemplate.postForEntity(
+                baseUrl("/auth/login"),
+                request,
+                AuthResponse.class
+        );
+
+        assertThat(loginResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        AuthResponse body = loginResponse.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getAccessToken()).isNotBlank();
+        assertThat(body.getRoles()).contains("SUPER_ADMIN");
+        assertThat(body.getPermissions()).contains("CUSTOMER_VIEW", "USER_VIEW");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(body.getAccessToken());
+
+        ResponseEntity<UserDto> currentUserResponse = restTemplate.exchange(
+                baseUrl("/auth/me"),
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                UserDto.class
+        );
+
+        assertThat(currentUserResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(currentUserResponse.getBody()).isNotNull();
+
+        ResponseEntity<String> customersResponse = restTemplate.exchange(
+                baseUrl("/customers"),
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                String.class
+        );
+
+        assertThat(customersResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private String baseUrl(String path) {
+        return "http://localhost:" + port + "/api/v1" + path;
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:rbac;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+app:
+  jwt:
+    secret: V1RY9m0xL8U7Q2pX5s6d8f1g2h3j4k5l6m7n8o9p0q1r2s3t4u5v6w7x8y9z0a
+    access-token-ttl-seconds: 900
+    refresh-token-ttl-seconds: 604800
+  cors:
+    allowed-origins:
+      - http://localhost:*
+      - http://127.0.0.1:*

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,6264 @@
+{
+  "name": "rbac-dashboard-frontend",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rbac-dashboard-frontend",
+      "version": "0.0.1",
+      "dependencies": {
+        "@reduxjs/toolkit": "^2.1.1",
+        "@tanstack/react-query": "^5.28.9",
+        "axios": "^1.6.7",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-redux": "^9.1.0",
+        "react-router-dom": "^6.22.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.17",
+        "@types/react": "^18.2.20",
+        "@types/react-dom": "^18.2.7",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "@vitejs/plugin-react": "3.1.0",
+        "autoprefixer": "^10.4.17",
+        "eslint": "^8.56.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "postcss": "^8.4.35",
+        "tailwindcss": "^3.4.1",
+        "typescript": "^5.3.3",
+        "vite": "^4.5.2"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
+      "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.1.0.tgz",
+      "integrity": "sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.20.12",
+        "@babel/plugin-transform-react-jsx-self": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.27.0",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.1.0-beta.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
+      "integrity": "sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.9",
+        "caniuse-lite": "^1.0.30001746",
+        "electron-to-chromium": "^1.5.227",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001747",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001747.tgz",
+      "integrity": "sha512-mzFa2DGIhuc5490Nd/G31xN1pnBnYMadtkyTjefPI7wzypqgCEpeWu9bJr0OnDsyKrW75zA9ZAt7pbQFmwLsQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.230",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.230.tgz",
+      "integrity": "sha512-A6A6Fd3+gMdaed9wX83CvHYJb4UuapPD5X5SLq72VZJzxHSY0/LUweGXRWmQlh2ln7KV7iw7jnwXK7dlPoOnHQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.6",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
+      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-import/node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sucrase/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
+      "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
+      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "3.1.0",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
@@ -33,6 +33,6 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "vite": "^5.0.12"
+    "vite": "^4.5.2"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import Layout from './components/Layout';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
@@ -7,7 +7,6 @@ import DashboardPage from './pages/DashboardPage';
 import UsersPage from './pages/UsersPage';
 import RolesPage from './pages/RolesPage';
 import PermissionsPage from './pages/PermissionsPage';
-import CustomersPage from './pages/CustomersPage';
 import InvoicesPage from './pages/InvoicesPage';
 import ProfilePage from './pages/ProfilePage';
 import ForbiddenPage from './pages/ForbiddenPage';
@@ -15,34 +14,76 @@ import NotFoundPage from './pages/NotFoundPage';
 import ProtectedRoute from './routes/ProtectedRoute';
 import PermissionRoute from './routes/PermissionRoute';
 import { useAppDispatch, useAppSelector } from './app/hooks';
-import { loadCurrentUser, tokensRefreshed } from './features/auth/authSlice';
+import { loadCurrentUser, logout as logoutAction, tokensRefreshed } from './features/auth/authSlice';
 import api from './services/http';
 
 const App = () => {
   const dispatch = useAppDispatch();
+  const location = useLocation();
   const { accessToken, refreshToken } = useAppSelector((state) => state.auth);
-  const [bootstrapped, setBootstrapped] = useState(false);
+  const [initializing, setInitializing] = useState<'idle' | 'checking'>(() =>
+    refreshToken ? 'checking' : 'idle'
+  );
 
   useEffect(() => {
-    const bootstrap = async () => {
+    let active = true;
+
+    const restoreSession = async () => {
       if (!accessToken && refreshToken) {
+        setInitializing('checking');
         try {
           const { data } = await api.post('/auth/refresh', { refreshToken });
+          if (!active) {
+            return;
+          }
           dispatch(tokensRefreshed(data));
         } catch (error) {
-          // ignore - user must sign in again
+          if (!active) {
+            return;
+          }
+          dispatch(logoutAction());
+          setInitializing('idle');
         }
+        return;
       }
+
       if (accessToken) {
-        dispatch(loadCurrentUser());
+        setInitializing('checking');
+        try {
+          await dispatch(loadCurrentUser()).unwrap();
+        } catch (error) {
+          if (!active) {
+            return;
+          }
+          dispatch(logoutAction());
+        } finally {
+          if (active) {
+            setInitializing('idle');
+          }
+        }
+        return;
       }
-      setBootstrapped(true);
+
+      if (active) {
+        setInitializing('idle');
+      }
     };
-    bootstrap();
+
+    restoreSession();
+
+    return () => {
+      active = false;
+    };
   }, [accessToken, refreshToken, dispatch]);
 
-  if (!bootstrapped && refreshToken) {
-    return <div className="flex min-h-screen items-center justify-center">Loading...</div>;
+  const isPublicRoute = location.pathname.startsWith('/login') || location.pathname.startsWith('/signup');
+
+  if (initializing === 'checking' && !isPublicRoute) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-sm text-slate-500">
+        Preparing your workspace…
+      </div>
+    );
   }
 
   return (
@@ -53,19 +94,45 @@ const App = () => {
         <Route element={<Layout />}>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<DashboardPage />} />
-          <Route element={<PermissionRoute required={['USER_VIEW', 'USER_CREATE', 'USER_UPDATE', 'USER_DELETE']} />}>
+          <Route
+            element={
+              <PermissionRoute
+                required={[
+                  'USER_VIEW',
+                  'USER_VIEW_GLOBAL',
+                  'USER_VIEW_OWN',
+                  'CUSTOMER_VIEW',
+                  'CUSTOMER_VIEW_GLOBAL',
+                  'CUSTOMER_VIEW_OWN',
+                  'CUSTOMER_CREATE',
+                  'CUSTOMER_UPDATE',
+                  'CUSTOMER_DELETE'
+                ]}
+              />
+            }
+          >
             <Route path="/users" element={<UsersPage />} />
           </Route>
-          <Route element={<PermissionRoute required={['ROLE_VIEW', 'PERMISSION_VIEW', 'ROLE_CREATE', 'ROLE_UPDATE']} />}>
+          <Route element={<PermissionRoute required={['ROLE_VIEW', 'ROLE_VIEW_GLOBAL', 'ROLE_VIEW_OWN']} />}>
             <Route path="/roles" element={<RolesPage />} />
           </Route>
           <Route element={<PermissionRoute required={['PERMISSION_VIEW']} />}>
             <Route path="/permissions" element={<PermissionsPage />} />
           </Route>
-          <Route element={<PermissionRoute required={['CUSTOMER_VIEW']} />}>
-            <Route path="/customers" element={<CustomersPage />} />
-          </Route>
-          <Route element={<PermissionRoute required={['INVOICE_VIEW']} />}>
+          <Route
+            element={
+              <PermissionRoute
+                required={[
+                  'INVOICE_VIEW',
+                  'INVOICE_VIEW_GLOBAL',
+                  'INVOICE_VIEW_OWN',
+                  'INVOICE_CREATE',
+                  'INVOICE_UPDATE',
+                  'INVOICE_DELETE'
+                ]}
+              />
+            }
+          >
             <Route path="/invoices" element={<InvoicesPage />} />
           </Route>
           <Route path="/profile" element={<ProfilePage />} />

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -7,12 +7,12 @@ interface DataTableProps {
 
 const DataTable = ({ title, children, actions }: PropsWithChildren<DataTableProps>) => {
   return (
-    <div className="rounded-lg border border-slate-200 bg-white shadow-sm">
-      <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+    <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-6 py-4">
         <h2 className="text-lg font-semibold text-slate-800">{title}</h2>
         {actions}
       </div>
-      <div className="overflow-x-auto px-4 py-2">
+      <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-slate-200 text-sm text-slate-700">
           {children}
         </table>

--- a/frontend/src/components/ExportMenu.tsx
+++ b/frontend/src/components/ExportMenu.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ExportFormat } from '../utils/exporters';
+
+const OPTIONS: Array<{ label: string; value: ExportFormat; description: string }> = [
+  { label: 'Excel (.xlsx)', value: 'xlsx', description: 'Download a spreadsheet of the current view.' },
+  { label: 'CSV (.csv)', value: 'csv', description: 'Export the visible rows as comma-separated values.' },
+  { label: 'PDF (.pdf)', value: 'pdf', description: 'Generate a printable PDF summary of the table.' },
+  { label: 'Print view', value: 'print', description: 'Open a print-friendly preview in a new tab.' }
+];
+
+const DownloadIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    className="h-4 w-4"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v12m0 0 4-4m-4 4-4-4" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 20h12" />
+  </svg>
+);
+
+const ChevronIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    className="h-4 w-4"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+  </svg>
+);
+
+interface ExportMenuProps {
+  onSelect: (format: ExportFormat) => void;
+  disabled?: boolean;
+  isBusy?: boolean;
+}
+
+const ExportMenu = ({ onSelect, disabled = false, isBusy = false }: ExportMenuProps) => {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleClick = (event: MouseEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (disabled || isBusy) {
+      setOpen(false);
+    }
+  }, [disabled, isBusy]);
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        disabled={disabled || isBusy}
+        className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <DownloadIcon />
+        <span>{isBusy ? 'Preparing…' : 'Export'}</span>
+        <ChevronIcon />
+      </button>
+      {open && (
+        <div className="absolute right-0 z-30 mt-2 w-64 rounded-xl border border-slate-200 bg-white shadow-xl">
+          <ul className="py-2 text-sm text-slate-600">
+            {OPTIONS.map((option) => (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false);
+                    onSelect(option.value);
+                  }}
+                  className="flex w-full flex-col items-start gap-1 px-4 py-2 text-left transition hover:bg-blue-50/70"
+                >
+                  <span className="font-semibold text-slate-700">{option.label}</span>
+                  <span className="text-xs text-slate-500">{option.description}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExportMenu;
+

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,20 +1,117 @@
-import { useMemo } from 'react';
-import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { logout } from '../features/auth/authSlice';
 import { TAB_RULES, hasAnyPermission } from '../utils/permissions';
 import type { PermissionKey } from '../types/auth';
 import api from '../services/http';
 
+type SidebarItem = {
+  key: string;
+  label: string;
+  to?: string;
+  icon?: string;
+  children?: SidebarItem[];
+};
+
 const Layout = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
   const { user, permissions, refreshToken } = useAppSelector((state) => state.auth);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
 
   const tabs = useMemo(() => {
     const keys = Object.keys(TAB_RULES);
     return keys.filter((tab) => hasAnyPermission(permissions as PermissionKey[], TAB_RULES[tab]));
   }, [permissions]);
+
+  const navigation = useMemo<SidebarItem[]>(() => {
+    const items: SidebarItem[] = [
+      {
+        key: 'dashboard',
+        label: 'Dashboard',
+        to: '/dashboard',
+        icon: '🏠'
+      }
+    ];
+
+    const salesChildren: SidebarItem[] = [];
+    if (tabs.includes('Invoices')) {
+      salesChildren.push({ key: 'invoices', label: 'Invoices', to: '/invoices' });
+    }
+    if (salesChildren.length) {
+      items.push({
+        key: 'sales',
+        label: 'Sales',
+        icon: '⚡',
+        children: salesChildren
+      });
+    }
+
+    const accessChildren: SidebarItem[] = [];
+    if (tabs.includes('Users')) {
+      accessChildren.push({ key: 'users', label: 'Users', to: '/users' });
+    }
+    if (tabs.includes('Roles')) {
+      accessChildren.push({ key: 'roles', label: 'Roles', to: '/roles' });
+    }
+    if (tabs.includes('Permissions')) {
+      accessChildren.push({ key: 'permissions', label: 'Permissions', to: '/permissions' });
+    }
+    if (accessChildren.length) {
+      items.push({
+        key: 'access',
+        label: 'Access Control',
+        icon: '🔐',
+        children: accessChildren
+      });
+    }
+
+    items.push({
+      key: 'profile',
+      label: 'Profile',
+      to: '/profile',
+      icon: '👤'
+    });
+
+    return items;
+  }, [tabs]);
+
+  useEffect(() => {
+    setExpandedSections((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      navigation.forEach((item) => {
+        if (!item.children) {
+          return;
+        }
+        const hasActiveChild = item.children.some((child) => child.to && location.pathname.startsWith(child.to));
+        if (hasActiveChild && !next[item.key]) {
+          next[item.key] = true;
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [location.pathname, navigation]);
+
+  const toggleSection = (key: string) => {
+    setExpandedSections((prev) => ({ ...prev, [key]: !(prev[key] ?? true) }));
+  };
+
+  const getInitials = () => {
+    if (!user?.fullName) {
+      return 'U';
+    }
+    const parts = user.fullName.trim().split(' ').filter(Boolean);
+    if (!parts.length) {
+      return 'U';
+    }
+    const initials = parts.map((part) => part.charAt(0).toUpperCase());
+    return (initials[0] ?? 'U') + (initials[1] ?? '');
+  };
 
   const handleLogout = async () => {
     if (refreshToken) {
@@ -25,18 +122,152 @@ const Layout = () => {
       }
     }
     dispatch(logout());
-    navigate('/login');
+    navigate('/login', { replace: true });
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <header className="bg-white shadow-sm">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
-          <h1 className="text-xl font-semibold text-slate-800">RBAC Dashboard</h1>
+    <div className="flex min-h-screen bg-slate-50">
+      <aside
+        className={`border-r border-slate-200 bg-white transition-all duration-300 ease-in-out ${
+          sidebarCollapsed ? 'w-20' : 'w-72'
+        }`}
+      >
+        <div className="flex h-16 items-center justify-between px-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary text-base font-semibold text-white">
+              RB
+            </div>
+            {!sidebarCollapsed && <span className="text-lg font-semibold text-slate-800">RBAC Portal</span>}
+          </div>
+          <button
+            type="button"
+            onClick={() => setSidebarCollapsed((prev) => !prev)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition-colors hover:bg-slate-100"
+            title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className={`h-5 w-5 transition-transform ${sidebarCollapsed ? 'rotate-180' : ''}`}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h10" />
+            </svg>
+          </button>
+        </div>
+        <div className="px-3">
+          <div
+            className={`mt-6 rounded-xl border border-slate-200 bg-slate-50 p-3 transition-all ${
+              sidebarCollapsed ? 'items-center px-0 py-4' : 'flex items-center gap-3'
+            }`}
+          >
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+              {getInitials()}
+            </div>
+            {!sidebarCollapsed && user && (
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-slate-800">{user.fullName}</p>
+                <p className="truncate text-xs text-slate-500">{user.email}</p>
+              </div>
+            )}
+            {!sidebarCollapsed && !user && (
+              <p className="text-sm font-medium text-slate-600">Welcome</p>
+            )}
+          </div>
+        </div>
+        <nav className="mt-6 space-y-1 px-2">
+          {navigation.map((item) => {
+            if (item.children?.length) {
+              const isExpanded = expandedSections[item.key] ?? true;
+              const isActive = item.children.some((child) => child.to && location.pathname.startsWith(child.to));
+
+              return (
+                <div key={item.key}>
+                  <button
+                    type="button"
+                    onClick={() => toggleSection(item.key)}
+                    className={`flex w-full items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                      sidebarCollapsed ? 'justify-center px-0' : 'gap-3'
+                    } ${
+                      isActive ? 'bg-primary/10 text-primary' : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                    }`}
+                    title={sidebarCollapsed ? item.label : undefined}
+                  >
+                    <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-base">
+                      {item.icon ?? item.label.charAt(0)}
+                    </span>
+                    {!sidebarCollapsed && <span className="flex-1 text-left">{item.label}</span>}
+                    {!sidebarCollapsed && (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        className={`h-4 w-4 transition-transform ${isExpanded ? '' : '-rotate-90'}`}
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                      </svg>
+                    )}
+                  </button>
+                  {isExpanded && !sidebarCollapsed && (
+                    <div className="mt-1 space-y-1 pl-12">
+                      {item.children.map((child) => (
+                        <NavLink
+                          key={child.key}
+                          to={child.to ?? '#'}
+                          className={({ isActive }) =>
+                            `flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors ${
+                              isActive
+                                ? 'bg-primary/10 font-medium text-primary'
+                                : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                            }`
+                          }
+                        >
+                          <span className="text-xs text-slate-400">•</span>
+                          <span>{child.label}</span>
+                        </NavLink>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            }
+
+            return (
+              <NavLink
+                key={item.key}
+                to={item.to ?? '#'}
+                end={item.to === '/dashboard'}
+                title={sidebarCollapsed ? item.label : undefined}
+                className={({ isActive }) =>
+                  `group flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                    sidebarCollapsed ? 'justify-center px-0' : 'gap-3'
+                  } ${
+                    isActive
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                  }`
+                }
+              >
+                <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-100 text-base">
+                  {item.icon ?? item.label.charAt(0)}
+                </span>
+                {!sidebarCollapsed && <span>{item.label}</span>}
+              </NavLink>
+            );
+          })}
+        </nav>
+      </aside>
+      <div className="flex flex-1 flex-col">
+        <header className="flex h-16 items-center justify-between border-b border-slate-200 bg-white px-6">
+          <h1 className="text-lg font-semibold text-slate-800">RBAC Dashboard</h1>
           <div className="flex items-center gap-4">
             {user && (
-              <div className="text-sm text-slate-600">
-                <p className="font-medium">{user.fullName}</p>
+              <div className="hidden text-right text-sm text-slate-600 md:block">
+                <p className="font-medium text-slate-800">{user.fullName}</p>
                 <p className="text-xs">{user.email}</p>
               </div>
             )}
@@ -47,46 +278,11 @@ const Layout = () => {
               Logout
             </button>
           </div>
-        </div>
-        <nav className="bg-slate-100">
-          <div className="mx-auto flex max-w-7xl gap-6 px-6 py-2 text-sm font-medium text-slate-600">
-            <NavLink to="/dashboard" className={({ isActive }) => (isActive ? 'text-primary' : '')} end>
-              Overview
-            </NavLink>
-            {tabs.includes('Users') && (
-              <NavLink to="/users" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
-                Users
-              </NavLink>
-            )}
-            {tabs.includes('Roles') && (
-              <NavLink to="/roles" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
-                Roles & Permissions
-              </NavLink>
-            )}
-            {tabs.includes('Permissions') && (
-              <NavLink to="/permissions" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
-                Permissions
-              </NavLink>
-            )}
-            {tabs.includes('Customers') && (
-              <NavLink to="/customers" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
-                Customers
-              </NavLink>
-            )}
-            {tabs.includes('Invoices') && (
-              <NavLink to="/invoices" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
-                Invoices
-              </NavLink>
-            )}
-            <NavLink to="/profile" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
-              Profile
-            </NavLink>
-          </div>
-        </nav>
-      </header>
-      <main className="mx-auto w-full max-w-7xl flex-1 px-6 py-8">
-        <Outlet />
-      </main>
+        </header>
+        <main className="flex-1 px-6 py-8">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/SortableColumnHeader.tsx
+++ b/frontend/src/components/SortableColumnHeader.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+type SortDirection = 'asc' | 'desc';
+
+interface SortableColumnHeaderProps<T extends string = string> {
+  label: string;
+  field: T;
+  currentField: string;
+  direction: SortDirection;
+  onSort: (field: T) => void;
+  align?: 'left' | 'center' | 'right';
+}
+
+const SortIndicator = ({ active, direction }: { active: boolean; direction: SortDirection }) => {
+  return (
+    <span className="ml-1 inline-flex flex-col leading-[0.6]">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        className={`h-2.5 w-2.5 ${active && direction === 'asc' ? 'text-primary' : 'text-slate-400'}`}
+        aria-hidden="true"
+      >
+        <path d="M8 4 4.5 8h7L8 4Z" fill="currentColor" />
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        className={`h-2.5 w-2.5 ${active && direction === 'desc' ? 'text-primary' : 'text-slate-400'}`}
+        aria-hidden="true"
+      >
+        <path d="M8 12 11.5 8h-7L8 12Z" fill="currentColor" />
+      </svg>
+    </span>
+  );
+};
+
+const alignmentClass: Record<'left' | 'center' | 'right', string> = {
+  left: 'justify-start text-left',
+  center: 'justify-center text-center',
+  right: 'justify-end text-right'
+};
+
+const SortableColumnHeader = <T extends string = string>({
+  label,
+  field,
+  currentField,
+  direction,
+  onSort,
+  align = 'left'
+}: SortableColumnHeaderProps<T>) => {
+  const isActive = currentField === field;
+  const ariaSort = isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none';
+
+  return (
+    <th scope="col" className="px-4 py-3" aria-sort={ariaSort}>
+      <button
+        type="button"
+        onClick={() => onSort(field)}
+        className={`flex w-full items-center gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500 transition hover:text-primary ${alignmentClass[align]}`}
+      >
+        <span>{label}</span>
+        <SortIndicator active={isActive} direction={direction} />
+      </button>
+    </th>
+  );
+};
+
+export default SortableColumnHeader;

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -1,0 +1,111 @@
+import { createContext, ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+export type ToastType = 'success' | 'error';
+
+export interface ToastOptions {
+  type: ToastType;
+  title?: string;
+  message: string;
+  duration?: number;
+}
+
+interface ToastRecord extends ToastOptions {
+  id: number;
+}
+
+interface ToastContextValue {
+  notify: (options: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const DEFAULT_DURATION = 3600;
+
+const typeStyles: Record<ToastType, string> = {
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  error: 'border-rose-200 bg-rose-50 text-rose-700'
+};
+
+const iconPaths: Record<ToastType, string> = {
+  success: 'M4.5 12.75l6 6 9-13.5',
+  error: 'm6 18 12-12M6 6l12 12'
+};
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+
+  const remove = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const notify = useCallback(
+    (options: ToastOptions) => {
+      const id = Date.now() + Math.floor(Math.random() * 1000);
+      const duration = options.duration ?? DEFAULT_DURATION;
+      const toast: ToastRecord = { id, ...options, duration };
+      setToasts((prev) => [...prev, toast]);
+      window.setTimeout(() => remove(id), duration);
+    },
+    [remove]
+  );
+
+  const value = useMemo(() => ({ notify }), [notify]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="pointer-events-none fixed right-5 top-5 z-[1200] flex w-full max-w-sm flex-col gap-3">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`pointer-events-auto flex items-start gap-3 rounded-xl border px-4 py-3 shadow-lg transition ${
+              typeStyles[toast.type]
+            }`}
+          >
+            <span className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-white/70">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.8}
+                className="h-5 w-5"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d={iconPaths[toast.type]} />
+              </svg>
+            </span>
+            <div className="flex-1">
+              {toast.title && <p className="text-sm font-semibold">{toast.title}</p>}
+              <p className="text-sm leading-5">{toast.message}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => remove(toast.id)}
+              className="ml-2 rounded-full p-1 text-sm text-slate-500 transition hover:bg-white/60 hover:text-slate-700"
+            >
+              <span className="sr-only">Dismiss notification</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.6}
+                className="h-4 w-4"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
+              </svg>
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import App from './App';
 import './styles/tailwind.css';
 import { injectStore, registerAuthListeners } from './services/http';
 import { tokensRefreshed, logout } from './features/auth/authSlice';
+import { ToastProvider } from './components/ToastProvider';
 
 injectStore(store);
 registerAuthListeners(
@@ -22,7 +23,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </BrowserRouter>
       </QueryClientProvider>
     </Provider>

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -5,42 +5,66 @@ import DataTable from '../components/DataTable';
 import type { Customer, Pagination } from '../types/models';
 import { useAppSelector } from '../app/hooks';
 import type { PermissionKey } from '../types/auth';
+import { hasAnyPermission } from '../utils/permissions';
+import { useToast } from '../components/ToastProvider';
+import { extractErrorMessage } from '../utils/errors';
 
 const CustomersPage = () => {
   const { permissions } = useAppSelector((state) => state.auth);
-  const canCreate = (permissions as PermissionKey[]).includes('CUSTOMER_CREATE');
-  const canDelete = (permissions as PermissionKey[]).includes('CUSTOMER_DELETE');
+  const grantedPermissions = permissions as PermissionKey[];
+  const canCreate = hasAnyPermission(grantedPermissions, ['CUSTOMER_CREATE']);
+  const canDelete = hasAnyPermission(grantedPermissions, ['CUSTOMER_DELETE']);
+  const { notify } = useToast();
 
-  const { data, refetch } = useQuery(['customers'], async () => {
-    const { data } = await api.get<Pagination<Customer>>('/customers');
-    return data.content;
+  const {
+    data: customers = [],
+    refetch
+  } = useQuery<Customer[]>({
+    queryKey: ['customers', 'all'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Customer>>('/customers');
+      return data.content;
+    }
   });
 
   const [form, setForm] = useState({ name: '', email: '', phone: '', address: '' });
+  const [formError, setFormError] = useState<string | null>(null);
 
-  const createCustomer = useMutation(
-    async () => {
+  const createCustomer = useMutation({
+    mutationFn: async () => {
       await api.post('/customers', form);
     },
-    {
-      onSuccess: () => {
-        setForm({ name: '', email: '', phone: '', address: '' });
-        refetch();
-      }
+    onSuccess: () => {
+      setForm({ name: '', email: '', phone: '', address: '' });
+      setFormError(null);
+      notify({ type: 'success', message: 'Customer created successfully.' });
+      refetch();
+    },
+    onError: (error) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Unable to create customer.') });
     }
-  );
+  });
 
-  const deleteCustomer = useMutation<void, unknown, number>(
-    async (id: number) => {
+  const deleteCustomer = useMutation<void, unknown, number>({
+    mutationFn: async (id: number) => {
       await api.delete(`/customers/${id}`);
     },
-    {
-      onSuccess: () => refetch()
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Customer removed.' });
+      refetch();
+    },
+    onError: (error) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Unable to remove customer.') });
     }
-  );
+  });
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
+    if (!form.name.trim()) {
+      setFormError('Name is required.');
+      return;
+    }
+    setFormError(null);
     createCustomer.mutate();
   };
 
@@ -58,6 +82,7 @@ const CustomersPage = () => {
                 value={form.name}
                 onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
                 required
+                minLength={2}
                 className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
               />
             </div>
@@ -88,12 +113,13 @@ const CustomersPage = () => {
               />
             </div>
           </div>
+          {formError && <p className="mt-2 text-sm text-red-600">{formError}</p>}
           <button
             type="submit"
             className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-            disabled={createCustomer.isLoading}
+            disabled={createCustomer.isPending}
           >
-            {createCustomer.isLoading ? 'Saving...' : 'Create customer'}
+            {createCustomer.isPending ? 'Saving...' : 'Create customer'}
           </button>
         </form>
       )}
@@ -109,7 +135,7 @@ const CustomersPage = () => {
           </tr>
         </thead>
         <tbody>
-          {data?.map((customer) => (
+          {customers.map((customer) => (
             <tr key={customer.id} className="border-t border-slate-200">
               <td className="px-3 py-2">{customer.name}</td>
               <td className="px-3 py-2">{customer.email ?? '—'}</td>
@@ -119,7 +145,8 @@ const CustomersPage = () => {
                 <td className="px-3 py-2 text-right">
                   <button
                     onClick={() => deleteCustomer.mutate(customer.id)}
-                    className="text-sm text-red-600 hover:underline"
+                    className="text-sm text-red-600 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={deleteCustomer.isPending}
                   >
                     Remove
                   </button>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,65 +1,250 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '../services/http';
-import type { Customer, Invoice, User } from '../types/models';
+import type { Customer, Invoice, Pagination, User } from '../types/models';
 import DataTable from '../components/DataTable';
 
+const SparkleIcon = () => (
+  <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 3.75 13.2 8.7l4.95 1.2-4.95 1.2-1.2 4.95-1.2-4.95L5.85 9.9l4.95-1.2L12 3.75Z"
+    />
+  </svg>
+);
+
+const UsersIcon = () => (
+  <svg className="h-8 w-8 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.25a7.5 7.5 0 0 1 15 0v.75h-15v-.75Z"
+    />
+  </svg>
+);
+
+const ChartIcon = () => (
+  <svg className="h-8 w-8 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 19.5 4.5 9.75m6 9.75V5.25m6 14.25v-6" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 20.25h18" />
+  </svg>
+);
+
+const ClipboardIcon = () => (
+  <svg className="h-8 w-8 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 4.5h6M9.75 3h4.5a1.5 1.5 0 0 1 1.5 1.5V6h2.25A1.5 1.5 0 0 1 19.5 7.5V19.5A1.5 1.5 0 0 1 18 21H6a1.5 1.5 0 0 1-1.5-1.5V7.5A1.5 1.5 0 0 1 6.75 6H9V4.5A1.5 1.5 0 0 1 10.5 3h3"
+    />
+  </svg>
+);
+
 const DashboardPage = () => {
-  const { data: users } = useQuery(['users'], async () => {
-    const { data } = await api.get<{ content: User[] }>('/users?size=5');
-    return data.content;
+  const { data: usersPage } = useQuery<Pagination<User>>({
+    queryKey: ['users', 'recent'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<User>>('/users?size=5');
+      return data;
+    }
   });
 
-  const { data: customers } = useQuery(['customers'], async () => {
-    const { data } = await api.get<{ content: Customer[] }>('/customers?size=5');
-    return data.content;
+  const { data: customersPage } = useQuery<Pagination<Customer>>({
+    queryKey: ['customers', 'recent'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Customer>>('/customers?size=5');
+      return data;
+    }
   });
 
-  const { data: invoices } = useQuery(['invoices'], async () => {
-    const { data } = await api.get<{ content: Invoice[] }>('/invoices?size=5');
-    return data.content;
+  const { data: invoicesPage } = useQuery<Pagination<Invoice>>({
+    queryKey: ['invoices', 'recent'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Invoice>>('/invoices?size=8');
+      return data;
+    }
   });
+
+  const users = usersPage?.content ?? [];
+  const customers = customersPage?.content ?? [];
+  const invoices = invoicesPage?.content ?? [];
+
+  const paidTotal = useMemo(
+    () => invoices.filter((invoice) => invoice.status === 'PAID').reduce((sum, invoice) => sum + invoice.total, 0),
+    [invoices]
+  );
+
+  const outstandingTotal = useMemo(
+    () => invoices.filter((invoice) => invoice.status !== 'PAID').reduce((sum, invoice) => sum + invoice.total, 0),
+    [invoices]
+  );
+
+  const draftCount = useMemo(() => invoices.filter((invoice) => invoice.status === 'DRAFT').length, [invoices]);
+  const sentCount = useMemo(() => invoices.filter((invoice) => invoice.status === 'SENT').length, [invoices]);
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 sm:grid-cols-3">
-        <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <p className="text-sm text-slate-500">Users</p>
-          <p className="mt-2 text-2xl font-semibold text-slate-800">{users?.length ?? 0}</p>
-        </div>
-        <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <p className="text-sm text-slate-500">Customers</p>
-          <p className="mt-2 text-2xl font-semibold text-slate-800">{customers?.length ?? 0}</p>
-        </div>
-        <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <p className="text-sm text-slate-500">Invoices</p>
-          <p className="mt-2 text-2xl font-semibold text-slate-800">{invoices?.length ?? 0}</p>
+      <div className="rounded-2xl bg-gradient-to-r from-primary/90 to-primary shadow-lg">
+        <div className="flex flex-col gap-4 px-6 py-6 text-white sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.25em] text-white/80">Dashboard overview</p>
+            <h1 className="mt-2 text-3xl font-semibold">Good to see you back, Admin</h1>
+            <p className="mt-2 max-w-2xl text-sm text-white/80">
+              Monitor engagement, track revenue, and stay ahead of upcoming work from a single, actionable workspace.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 text-sm sm:text-right">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1 text-white">
+              <SparkleIcon />
+              Daily summary refreshed moments ago
+            </span>
+            <button className="rounded-md bg-white px-4 py-2 font-semibold text-primary shadow-sm transition hover:bg-slate-100">
+              Customize dashboard
+            </button>
+          </div>
         </div>
       </div>
 
-      <DataTable title="Recent Invoices">
-        <thead>
-          <tr>
-            <th className="px-3 py-2 text-left">Number</th>
-            <th className="px-3 py-2 text-left">Customer</th>
-            <th className="px-3 py-2 text-left">Status</th>
-            <th className="px-3 py-2 text-right">Total</th>
-          </tr>
-        </thead>
-        <tbody>
-          {invoices?.map((invoice) => (
-            <tr key={invoice.id} className="border-t border-slate-200">
-              <td className="px-3 py-2">{invoice.number}</td>
-              <td className="px-3 py-2">{invoice.customerName}</td>
-              <td className="px-3 py-2">
-                <span className="rounded-full bg-slate-100 px-2 py-1 text-xs uppercase tracking-wide text-slate-600">
-                  {invoice.status}
-                </span>
-              </td>
-              <td className="px-3 py-2 text-right">${invoice.total.toFixed(2)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </DataTable>
+      <div className="grid gap-4 lg:grid-cols-4">
+        <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Active users</p>
+              <p className="mt-2 text-3xl font-semibold text-slate-900">{usersPage?.totalElements ?? 0}</p>
+              <p className="mt-1 text-xs text-emerald-600">+4 this week</p>
+            </div>
+            <UsersIcon />
+          </div>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Customers</p>
+              <p className="mt-2 text-3xl font-semibold text-slate-900">{customersPage?.totalElements ?? 0}</p>
+              <p className="mt-1 text-xs text-slate-500">Top clients listed below</p>
+            </div>
+            <ChartIcon />
+          </div>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Invoices paid</p>
+              <p className="mt-2 text-3xl font-semibold text-slate-900">${paidTotal.toFixed(2)}</p>
+              <p className="mt-1 text-xs text-emerald-600">Up to date</p>
+            </div>
+            <ClipboardIcon />
+          </div>
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Outstanding</p>
+              <p className="mt-2 text-3xl font-semibold text-slate-900">${outstandingTotal.toFixed(2)}</p>
+              <p className="mt-1 text-xs text-amber-600">{sentCount} sent • {draftCount} drafts</p>
+            </div>
+            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-amber-100 text-amber-500">!</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          <DataTable title="Recent invoices">
+            <thead>
+              <tr>
+                <th className="px-3 py-2 text-left">Number</th>
+                <th className="px-3 py-2 text-left">Customer</th>
+                <th className="px-3 py-2 text-left">Status</th>
+                <th className="px-3 py-2 text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {invoices.map((invoice) => (
+                <tr key={invoice.id} className="border-t border-slate-200">
+                  <td className="px-3 py-2 font-medium text-slate-700">{invoice.number}</td>
+                  <td className="px-3 py-2 text-sm text-slate-600">{invoice.customerName}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide ${
+                        invoice.status === 'PAID'
+                          ? 'bg-emerald-100 text-emerald-700'
+                          : invoice.status === 'SENT'
+                          ? 'bg-blue-100 text-blue-700'
+                          : 'bg-slate-100 text-slate-600'
+                      }`}
+                    >
+                      {invoice.status}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-right font-semibold text-slate-700">${invoice.total.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </DataTable>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-slate-800">Top customers</h2>
+              <span className="text-xs uppercase tracking-wide text-slate-500">Relationship health</span>
+            </div>
+            <ul className="mt-4 space-y-3">
+              {customers.map((customer) => (
+                <li key={customer.id} className="flex items-center justify-between rounded-lg border border-slate-100 px-4 py-3">
+                  <div>
+                    <p className="font-medium text-slate-800">{customer.name}</p>
+                    {customer.email && <p className="text-xs text-slate-500">{customer.email}</p>}
+                  </div>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Active</span>
+                </li>
+              ))}
+              {!customers.length && <li className="text-sm text-slate-500">No customers yet.</li>}
+            </ul>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-800">Today&apos;s focus</h2>
+            <ul className="mt-4 space-y-3 text-sm text-slate-600">
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-primary"></span>
+                Follow up with clients awaiting proposals.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-emerald-500"></span>
+                Review outstanding invoices and send reminders.
+              </li>
+              <li className="flex items-start gap-3">
+                <span className="mt-1 h-2 w-2 rounded-full bg-amber-500"></span>
+                Approve new user access requests submitted overnight.
+              </li>
+            </ul>
+            <button className="mt-6 inline-flex items-center justify-center rounded-md border border-primary px-4 py-2 text-sm font-semibold text-primary transition hover:bg-primary hover:text-white">
+              View full agenda
+            </button>
+          </div>
+
+          <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-800">Need help?</h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Our support team is online and ready to help configure automations, share best practices, and onboard your team.
+            </p>
+            <div className="mt-4 space-y-2 text-sm">
+              <p>
+                <span className="font-semibold text-slate-800">Live chat:</span> Monday–Friday 8am–6pm
+              </p>
+              <p>
+                <span className="font-semibold text-slate-800">Email:</span> support@example.com
+              </p>
+            </div>
+            <button className="mt-6 w-full rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90">
+              Chat with us
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/InvoicesPage.tsx
+++ b/frontend/src/pages/InvoicesPage.tsx
@@ -2,20 +2,37 @@ import { FormEvent, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import api from '../services/http';
 import DataTable from '../components/DataTable';
-import type { Invoice, Pagination } from '../types/models';
+import type { Invoice, InvoiceItem, Pagination } from '../types/models';
 import { useAppSelector } from '../app/hooks';
 import type { PermissionKey } from '../types/auth';
+import { useToast } from '../components/ToastProvider';
+import { extractErrorMessage } from '../utils/errors';
+import { hasAnyPermission } from '../utils/permissions';
+import ExportMenu from '../components/ExportMenu';
+import { exportDataset, type ExportFormat } from '../utils/exporters';
 
 const initialItem = { description: '', qty: 1, unitPrice: 0 };
 
 const InvoicesPage = () => {
   const { permissions } = useAppSelector((state) => state.auth);
-  const canCreate = (permissions as PermissionKey[]).includes('INVOICE_CREATE');
-  const canDelete = (permissions as PermissionKey[]).includes('INVOICE_DELETE');
+  const grantedPermissions = permissions as PermissionKey[];
+  const canCreate = hasAnyPermission(grantedPermissions, ['INVOICE_CREATE']);
+  const canDelete = hasAnyPermission(grantedPermissions, ['INVOICE_DELETE']);
+  const canUpdate = hasAnyPermission(grantedPermissions, ['INVOICE_UPDATE']);
+  const canExport = hasAnyPermission(grantedPermissions, ['INVOICES_EXPORT']);
+  const { notify } = useToast();
+  const [isExporting, setIsExporting] = useState(false);
 
-  const { data, refetch } = useQuery(['invoices'], async () => {
-    const { data } = await api.get<Pagination<Invoice>>('/invoices');
-    return data.content;
+  const {
+    data: invoices = [],
+    refetch,
+    isLoading: isLoadingInvoices
+  } = useQuery<Invoice[]>({
+    queryKey: ['invoices', 'all'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Invoice>>('/invoices');
+      return data.content;
+    }
   });
 
   const [form, setForm] = useState({
@@ -23,47 +40,222 @@ const InvoicesPage = () => {
     number: '',
     issueDate: '',
     dueDate: '',
+    status: 'DRAFT' as Invoice['status'],
     taxRate: 10,
-    item: initialItem
+    item: initialItem,
+    existingItems: [] as InvoiceItem[]
   });
+  const [formError, setFormError] = useState<string | null>(null);
+  const [editingInvoiceId, setEditingInvoiceId] = useState<number | null>(null);
 
-  const createInvoice = useMutation(
-    async () => {
+  const buildInvoiceItems = (): Array<Pick<InvoiceItem, 'description' | 'qty' | 'unitPrice'>> => {
+    if (editingInvoiceId && form.existingItems.length > 0) {
+      return form.existingItems.map((item, index) => {
+        if (index === 0) {
+          return {
+            description: form.item.description,
+            qty: form.item.qty,
+            unitPrice: Number(form.item.unitPrice)
+          };
+        }
+        return {
+          description: item.description,
+          qty: Number(item.qty),
+          unitPrice: Number(item.unitPrice)
+        };
+      });
+    }
+    return [
+      {
+        description: form.item.description,
+        qty: form.item.qty,
+        unitPrice: Number(form.item.unitPrice)
+      }
+    ];
+  };
+
+  const resetForm = () => {
+    setForm({
+      customerId: '',
+      number: '',
+      issueDate: '',
+      dueDate: '',
+      status: 'DRAFT',
+      taxRate: 10,
+      item: { ...initialItem },
+      existingItems: []
+    });
+    setFormError(null);
+    setEditingInvoiceId(null);
+  };
+
+  const isEditing = editingInvoiceId !== null;
+
+  const createInvoice = useMutation({
+    mutationFn: async () => {
       await api.post('/invoices', {
         customerId: Number(form.customerId),
         number: form.number,
         issueDate: form.issueDate,
         dueDate: form.dueDate,
-        status: 'DRAFT',
+        status: form.status,
         taxRate: form.taxRate,
-        items: [form.item]
+        items: buildInvoiceItems()
       });
     },
-    {
-      onSuccess: () => {
-        setForm({ customerId: '', number: '', issueDate: '', dueDate: '', taxRate: 10, item: { ...initialItem } });
-        refetch();
-      }
+    onSuccess: () => {
+      resetForm();
+      notify({ type: 'success', message: 'Invoice created successfully.' });
+      refetch();
+    },
+    onError: (error) => {
+      const message = extractErrorMessage(error, 'Unable to create invoice.');
+      setFormError(message);
+      notify({ type: 'error', message });
     }
-  );
+  });
 
-  const deleteInvoice = useMutation<void, unknown, number>(
-    async (id: number) => {
+  const deleteInvoice = useMutation<void, unknown, number>({
+    mutationFn: async (id: number) => {
       await api.delete(`/invoices/${id}`);
     },
-    {
-      onSuccess: () => refetch()
+    onSuccess: (_, id) => {
+      notify({ type: 'success', message: 'Invoice removed.' });
+      refetch();
+      if (editingInvoiceId === id) {
+        resetForm();
+      }
+    },
+    onError: (error) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Unable to remove invoice.') });
     }
-  );
+  });
+
+  const updateInvoice = useMutation({
+    mutationFn: async () => {
+      if (!editingInvoiceId) {
+        return null;
+      }
+      const { data } = await api.put<Invoice>(`/invoices/${editingInvoiceId}`, {
+        customerId: Number(form.customerId),
+        number: form.number,
+        issueDate: form.issueDate,
+        dueDate: form.dueDate,
+        status: form.status,
+        taxRate: form.taxRate,
+        items: buildInvoiceItems()
+      });
+      return data;
+    },
+    onSuccess: (data) => {
+      if (data) {
+        notify({ type: 'success', message: 'Invoice updated successfully.' });
+        resetForm();
+        refetch();
+      }
+    },
+    onError: (error) => {
+      const message = extractErrorMessage(error, 'Unable to update invoice.');
+      setFormError(message);
+      notify({ type: 'error', message });
+    }
+  });
+
+  const isSaving = isEditing ? updateInvoice.isPending : createInvoice.isPending;
+  const isDeleting = deleteInvoice.isPending;
+
+  const showActions = canDelete || canUpdate;
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    createInvoice.mutate();
+    if (!form.customerId || !form.number.trim()) {
+      setFormError('Customer ID and invoice number are required.');
+      notify({ type: 'error', message: 'Customer ID and invoice number are required.' });
+      return;
+    }
+    setFormError(null);
+    if (isEditing) {
+      updateInvoice.mutate();
+    } else {
+      createInvoice.mutate();
+    }
+  };
+
+  const handleExportInvoices = (format: ExportFormat) => {
+    if (!canExport || isExporting) {
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const columns = [
+        { key: 'number', header: 'Number' },
+        { key: 'customer', header: 'Customer' },
+        { key: 'status', header: 'Status' },
+        { key: 'issueDate', header: 'Issue Date' },
+        { key: 'dueDate', header: 'Due Date' },
+        { key: 'total', header: 'Total' }
+      ];
+      const rows = (invoices ?? []).map((invoice) => ({
+        number: invoice.number,
+        customer: invoice.customerName,
+        status: invoice.status,
+        issueDate: invoice.issueDate,
+        dueDate: invoice.dueDate,
+        total: invoice.total.toFixed(2)
+      }));
+      if (!rows.length) {
+        notify({ type: 'error', message: 'There are no invoices to export.' });
+        return;
+      }
+      exportDataset({
+        format,
+        columns,
+        rows,
+        fileName: 'invoices',
+        title: 'Invoices'
+      });
+    } catch (error) {
+      notify({ type: 'error', message: 'Unable to export invoices. Please try again.' });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const beginEdit = (invoice: Invoice) => {
+    const [firstItem] = invoice.items;
+    const computedTaxRate = invoice.subtotal === 0 ? 0 : Number(((invoice.tax / invoice.subtotal) * 100).toFixed(2));
+    setEditingInvoiceId(invoice.id);
+    setForm({
+      customerId: String(invoice.customerId),
+      number: invoice.number,
+      issueDate: invoice.issueDate,
+      dueDate: invoice.dueDate,
+      status: invoice.status,
+      taxRate: computedTaxRate,
+      item: firstItem
+        ? { description: firstItem.description, qty: firstItem.qty, unitPrice: Number(firstItem.unitPrice) }
+        : { ...initialItem },
+      existingItems: invoice.items?.map((item) => ({ ...item })) ?? []
+    });
+    setFormError(null);
+  };
+
+  const cancelEdit = () => {
+    resetForm();
   };
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-slate-800">Invoices</h1>
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <h1 className="text-2xl font-semibold text-slate-800">Invoices</h1>
+        {canExport && (
+          <ExportMenu
+            onSelect={handleExportInvoices}
+            disabled={isLoadingInvoices}
+            isBusy={isExporting}
+          />
+        )}
+      </div>
 
       {canCreate && (
         <form onSubmit={handleSubmit} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
@@ -96,6 +288,20 @@ const InvoicesPage = () => {
                 onChange={(e) => setForm((prev) => ({ ...prev, taxRate: Number(e.target.value) }))}
                 className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
               />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Invoice status</label>
+              <select
+                value={form.status}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, status: e.target.value as Invoice['status'] }))
+                }
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              >
+                <option value="DRAFT">Draft</option>
+                <option value="SENT">Sent</option>
+                <option value="PAID">Paid</option>
+              </select>
             </div>
             <div>
               <label className="block text-sm font-medium text-slate-600">Issue date</label>
@@ -149,13 +355,26 @@ const InvoicesPage = () => {
               />
             </div>
           </div>
-          <button
-            type="submit"
-            className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-            disabled={createInvoice.isLoading}
-          >
-            {createInvoice.isLoading ? 'Saving...' : 'Create invoice'}
-          </button>
+          {formError && <p className="mt-3 text-sm text-red-600">{formError}</p>}
+          <div className="mt-4 flex items-center gap-3">
+            {isEditing && (
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isSaving}
+              >
+                Cancel edit
+              </button>
+            )}
+            <button
+              type="submit"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={isSaving}
+            >
+              {isSaving ? 'Saving…' : isEditing ? 'Update invoice' : 'Create invoice'}
+            </button>
+          </div>
         </form>
       )}
 
@@ -166,24 +385,40 @@ const InvoicesPage = () => {
             <th className="px-3 py-2 text-left">Customer</th>
             <th className="px-3 py-2 text-left">Status</th>
             <th className="px-3 py-2 text-right">Total</th>
-            {canDelete && <th className="px-3 py-2 text-right">Actions</th>}
+            {showActions && <th className="px-3 py-2 text-right">Actions</th>}
           </tr>
         </thead>
         <tbody>
-          {data?.map((invoice) => (
+          {invoices.map((invoice) => (
             <tr key={invoice.id} className="border-t border-slate-200">
               <td className="px-3 py-2">{invoice.number}</td>
               <td className="px-3 py-2">{invoice.customerName}</td>
               <td className="px-3 py-2">{invoice.status}</td>
               <td className="px-3 py-2 text-right">${invoice.total.toFixed(2)}</td>
-              {canDelete && (
+              {showActions && (
                 <td className="px-3 py-2 text-right">
-                  <button
-                    onClick={() => deleteInvoice.mutate(invoice.id)}
-                    className="text-sm text-red-600 hover:underline"
-                  >
-                    Remove
-                  </button>
+                  <div className="flex items-center justify-end gap-3">
+                    {canUpdate && (
+                      <button
+                        type="button"
+                        onClick={() => beginEdit(invoice)}
+                        className="text-sm text-blue-600 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={isSaving || isDeleting}
+                      >
+                        {editingInvoiceId === invoice.id ? 'Editing' : 'Edit'}
+                      </button>
+                    )}
+                    {canDelete && (
+                      <button
+                        type="button"
+                        onClick={() => deleteInvoice.mutate(invoice.id)}
+                        className="text-sm text-red-600 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={isDeleting}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
                 </td>
               )}
             </tr>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,20 +1,40 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { login } from '../features/auth/authSlice';
+import { useToast } from '../components/ToastProvider';
 
 const LoginPage = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const { status, error } = useAppSelector((state) => state.auth);
+  const { notify } = useToast();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [showErrorDialog, setShowErrorDialog] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (status === 'failed' && error) {
+      setErrorMessage(error);
+      setShowErrorDialog(true);
+    }
+  }, [status, error]);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
+    setShowErrorDialog(false);
+    setErrorMessage(null);
     const result = await dispatch(login({ email, password }));
     if (login.fulfilled.match(result)) {
+      notify({ type: 'success', message: 'Signed in successfully.' });
       navigate('/dashboard');
+    } else if (login.rejected.match(result)) {
+      const message = result.payload ?? 'Unable to sign in right now.';
+      setErrorMessage(message);
+      setShowErrorDialog(true);
+      notify({ type: 'error', message });
     }
   };
 
@@ -36,15 +56,41 @@ const LoginPage = () => {
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-600">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
-            />
+            <div className="mt-1 flex items-center rounded-md border border-slate-300 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="w-full rounded-l-md border-none px-3 py-2 text-sm focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((prev) => !prev)}
+                className="flex h-10 w-10 items-center justify-center rounded-r-md text-slate-500 transition hover:text-slate-700"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? (
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} className="h-5 w-5">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3.53 3.53 20.47 20.47M9.88 9.88a3 3 0 0 0 4.24 4.24M6.71 6.73A11.05 11.05 0 0 0 1.458 12C3.195 15.908 7.272 19 12 19c1.82 0 3.53-.43 5.049-1.194M9.88 9.88 6.71 6.73m7.41 7.39 3.13 3.15M21.542 12A11.05 11.05 0 0 0 17.29 7.27M14.12 14.12l3.17 3.17M9.88 9.88l4.24 4.24M14.12 9.88a3 3 0 0 0-4.24 4.24"
+                    />
+                  </svg>
+                ) : (
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} className="h-5 w-5">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
+                    />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                  </svg>
+                )}
+              </button>
+            </div>
           </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
           <button
             type="submit"
             className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-blue-600"
@@ -60,6 +106,39 @@ const LoginPage = () => {
           </Link>
         </p>
       </div>
+      {showErrorDialog && errorMessage && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
+            <div className="flex items-center gap-3">
+              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-rose-100 text-rose-600">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.8}
+                  className="h-5 w-5"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m0 3.75h.007M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+              </span>
+              <div>
+                <h3 className="text-base font-semibold text-slate-800">We couldn&apos;t sign you in</h3>
+                <p className="mt-1 text-sm text-slate-500">{errorMessage}</p>
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowErrorDialog(false)}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/PermissionsPage.tsx
+++ b/frontend/src/pages/PermissionsPage.tsx
@@ -1,85 +1,197 @@
-import { FormEvent, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import api from '../services/http';
-import DataTable from '../components/DataTable';
 import type { Pagination, Permission } from '../types/models';
+import SortableColumnHeader from '../components/SortableColumnHeader';
+import { useAppSelector } from '../app/hooks';
+import type { PermissionKey } from '../types/auth';
+import { hasAnyPermission } from '../utils/permissions';
+import ExportMenu from '../components/ExportMenu';
+import { exportDataset, type ExportFormat } from '../utils/exporters';
+import { useToast } from '../components/ToastProvider';
 
 const PermissionsPage = () => {
-  const { data, refetch } = useQuery(['permissions'], async () => {
-    const { data } = await api.get<Pagination<Permission>>('/permissions?size=200');
-    return data.content;
+  const { notify } = useToast();
+  const { permissions: authPermissions } = useAppSelector((state) => state.auth);
+  const grantedPermissions = (authPermissions ?? []) as PermissionKey[];
+  const canExportPermissions = useMemo(
+    () => hasAnyPermission(grantedPermissions, ['PERMISSIONS_EXPORT']),
+    [grantedPermissions]
+  );
+  const [isExporting, setIsExporting] = useState(false);
+
+  const [searchDraft, setSearchDraft] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sort, setSort] = useState<{ field: 'key' | 'name'; direction: 'asc' | 'desc' }>({
+    field: 'key',
+    direction: 'asc'
   });
 
-  const [form, setForm] = useState({ key: '', name: '' });
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearchTerm(searchDraft.trim());
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
 
-  const createPermission = useMutation(
-    async () => {
-      await api.post('/permissions', form);
-    },
-    {
-      onSuccess: () => {
-        setForm({ key: '', name: '' });
-        refetch();
-      }
+  const {
+    data: permissions = [],
+    isLoading
+  } = useQuery<Permission[]>({
+    queryKey: ['permissions', 'all'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Permission>>('/permissions?size=500');
+      return data.content;
     }
-  );
+  });
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    createPermission.mutate();
+  const filteredPermissions = useMemo(() => {
+    if (!searchTerm) {
+      return permissions;
+    }
+    const term = searchTerm.toLowerCase();
+    return permissions.filter((permission) =>
+      permission.key.toLowerCase().includes(term) || permission.name.toLowerCase().includes(term)
+    );
+  }, [permissions, searchTerm]);
+
+  const sortedPermissions = useMemo(() => {
+    const list = [...filteredPermissions];
+    const factor = sort.direction === 'asc' ? 1 : -1;
+    list.sort((a, b) => {
+      if (sort.field === 'key') {
+        return a.key.localeCompare(b.key, undefined, { sensitivity: 'base' }) * factor;
+      }
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) * factor;
+    });
+    return list;
+  }, [filteredPermissions, sort]);
+
+  const handleSortChange = (field: 'key' | 'name') => {
+    setSort((prev) => {
+      if (prev.field === field) {
+        return { field, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { field, direction: 'asc' };
+    });
+  };
+
+  const handleExportPermissions = (format: ExportFormat) => {
+    if (!canExportPermissions || isExporting) {
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const columns = [
+        { key: 'key', header: 'Key' },
+        { key: 'name', header: 'Name' }
+      ];
+      const rows = sortedPermissions.map((permission) => ({
+        key: permission.key,
+        name: permission.name
+      }));
+      if (!rows.length) {
+        notify({ type: 'error', message: 'There are no permissions to export for the current search.' });
+        return;
+      }
+      exportDataset({
+        format,
+        columns,
+        rows,
+        fileName: 'permissions',
+        title: 'Permissions'
+      });
+    } catch (error) {
+      notify({ type: 'error', message: 'Unable to export permissions. Please try again.' });
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-slate-800">Permissions</h1>
-      <form onSubmit={handleSubmit} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Key</label>
+    <div className="flex min-h-full flex-col gap-6 px-6 py-6">
+      <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">Permissions</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Review every permission provisioned by the platform so you can assign the right capabilities to roles and users.
+          </p>
+        </div>
+        {canExportPermissions && (
+          <ExportMenu
+            onSelect={handleExportPermissions}
+            disabled={isLoading}
+            isBusy={isExporting}
+          />
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total permissions</p>
+          <p className="mt-2 text-3xl font-semibold text-slate-800">{permissions.length}</p>
+          <p className="mt-1 text-xs text-slate-500">Automatically managed from your service catalogue.</p>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-col gap-4 border-b border-slate-200 px-6 py-4 lg:flex-row lg:items-end">
+          <div className="flex-1">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Search</label>
             <input
-              type="text"
-              value={form.key}
-              onChange={(e) => setForm((prev) => ({ ...prev, key: e.target.value }))}
-              required
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Name</label>
-            <input
-              type="text"
-              value={form.name}
-              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-              required
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              type="search"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+              placeholder="Search by permission key or name"
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
             />
           </div>
         </div>
-        <button
-          type="submit"
-          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-          disabled={createPermission.isLoading}
-        >
-          {createPermission.isLoading ? 'Saving...' : 'Create permission'}
-        </button>
-      </form>
-
-      <DataTable title="Available permissions">
-        <thead>
-          <tr>
-            <th className="px-3 py-2 text-left">Key</th>
-            <th className="px-3 py-2 text-left">Name</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data?.map((permission) => (
-            <tr key={permission.id} className="border-t border-slate-200">
-              <td className="px-3 py-2 uppercase tracking-wide text-slate-500">{permission.key}</td>
-              <td className="px-3 py-2">{permission.name}</td>
-            </tr>
-          ))}
-        </tbody>
-      </DataTable>
+        <div className="flex-1 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200">
+            <thead className="bg-slate-50">
+              <tr>
+                <SortableColumnHeader
+                  label="Key"
+                  field="key"
+                  currentField={sort.field}
+                  direction={sort.direction}
+                  onSort={handleSortChange}
+                />
+                <SortableColumnHeader
+                  label="Name"
+                  field="name"
+                  currentField={sort.field}
+                  direction={sort.direction}
+                  onSort={handleSortChange}
+                />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {isLoading ? (
+                <tr>
+                  <td colSpan={2} className="px-4 py-6 text-center text-sm text-slate-500">
+                    Loading permissions…
+                  </td>
+                </tr>
+              ) : sortedPermissions.length === 0 ? (
+                <tr>
+                  <td colSpan={2} className="px-4 py-6 text-center text-sm text-slate-500">
+                    No permissions match your search.
+                  </td>
+                </tr>
+              ) : (
+                sortedPermissions.map((permission) => (
+                  <tr key={permission.id} className="transition hover:bg-blue-50/40">
+                    <td className="px-4 py-3 text-sm font-semibold uppercase tracking-wide text-slate-500">{permission.key}</td>
+                    <td className="px-4 py-3 text-sm text-slate-600">{permission.name}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,28 +3,48 @@ import { useMutation } from '@tanstack/react-query';
 import api from '../services/http';
 import { useAppSelector, useAppDispatch } from '../app/hooks';
 import { loadCurrentUser } from '../features/auth/authSlice';
+import { useToast } from '../components/ToastProvider';
+import { extractErrorMessage } from '../utils/errors';
 
 const ProfilePage = () => {
   const dispatch = useAppDispatch();
   const { user } = useAppSelector((state) => state.auth);
   const [form, setForm] = useState({ fullName: user?.fullName ?? '', password: '' });
-  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { notify } = useToast();
 
-  const updateProfile = useMutation(
-    async () => {
+  const updateProfile = useMutation({
+    mutationFn: async () => {
       await api.put('/profile', form);
     },
-    {
-      onSuccess: () => {
-        setMessage('Profile updated successfully');
-        setForm((prev) => ({ ...prev, password: '' }));
-        dispatch(loadCurrentUser());
-      }
+    onSuccess: () => {
+      setForm((prev) => ({ ...prev, password: '' }));
+      setError(null);
+      dispatch(loadCurrentUser());
+      notify({ type: 'success', message: 'Profile updated successfully.' });
+    },
+    onError: (err) => {
+      const message = extractErrorMessage(err, 'Unable to update profile.');
+      setError(message);
+      notify({ type: 'error', message });
     }
-  );
+  });
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
+    if (!form.fullName.trim()) {
+      const message = 'Full name is required.';
+      setError(message);
+      notify({ type: 'error', message });
+      return;
+    }
+    if (form.password && form.password.length > 0 && form.password.length < 8) {
+      const message = 'Password must be at least 8 characters long.';
+      setError(message);
+      notify({ type: 'error', message });
+      return;
+    }
+    setError(null);
     updateProfile.mutate();
   };
 
@@ -57,11 +77,11 @@ const ProfilePage = () => {
         <button
           type="submit"
           className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-          disabled={updateProfile.isLoading}
+          disabled={updateProfile.isPending}
         >
-          {updateProfile.isLoading ? 'Saving...' : 'Save changes'}
+          {updateProfile.isPending ? 'Saving...' : 'Save changes'}
         </button>
-        {message && <p className="mt-4 text-sm text-green-600">{message}</p>}
+        {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
       </form>
     </div>
   );

--- a/frontend/src/pages/RolesPage.tsx
+++ b/frontend/src/pages/RolesPage.tsx
@@ -1,166 +1,1066 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { Dispatch, FormEvent, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
 import api from '../services/http';
-import DataTable from '../components/DataTable';
-import type { Pagination, Role, Permission } from '../types/models';
+import type { Pagination, Permission, Role } from '../types/models';
+import type { PermissionKey } from '../types/auth';
+import { useToast } from '../components/ToastProvider';
+import { CAPABILITY_COLUMNS, type PermissionGroup, buildPermissionGroups } from '../utils/permissionGroups';
+import SortableColumnHeader from '../components/SortableColumnHeader';
+import { useAppSelector } from '../app/hooks';
+import { hasAnyPermission } from '../utils/permissions';
+import ExportMenu from '../components/ExportMenu';
+import { exportDataset, type ExportFormat } from '../utils/exporters';
+
+const CUSTOMER_ROLE_KEY = 'CUSTOMER';
+
+type DirectoryView = 'list' | 'create' | 'edit';
+
+type ToggleOptions = {
+  deselect?: number[];
+  select?: number[];
+};
+
+type RoleSortField = 'name' | 'key' | 'audience' | 'permissionCount';
+
+const formatRoleKey = (value: string) =>
+  value
+    .trim()
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase();
+
+const toTitleCase = (value: string) =>
+  value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.substring(1).toLowerCase());
+
+const getErrorMessage = (error: unknown) => {
+  if (!error) {
+    return 'Something went wrong while processing the request.';
+  }
+
+  const axiosError = error as AxiosError<{ message?: string; error?: string }>;
+  const responseMessage = axiosError?.response?.data?.message ?? axiosError?.response?.data?.error;
+  if (responseMessage) {
+    return responseMessage;
+  }
+
+  if (axiosError?.message) {
+    return axiosError.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Something went wrong while processing the request.';
+};
+
+const isCustomerRole = (role: Role) => role.key.toUpperCase() === CUSTOMER_ROLE_KEY;
+
+const compareText = (a: string, b: string) => a.localeCompare(b, undefined, { sensitivity: 'base' });
+
+const PermissionMatrix = ({
+  groups,
+  selected,
+  onToggle
+}: {
+  groups: PermissionGroup[];
+  selected: number[];
+  onToggle: (permissionId: number, checked: boolean, options?: ToggleOptions) => void;
+}) => {
+  if (!groups.length) {
+    return (
+      <div className="px-6 py-8 text-center text-sm text-slate-500">
+        No permissions have been published yet.
+      </div>
+    );
+  }
+
+  const visibleColumns = CAPABILITY_COLUMNS.filter((column) =>
+    groups.some((group) => Boolean(group.slots[column.slot]))
+  );
+  const showExtras = groups.some((group) => group.extras.length > 0);
+  const selectedSet = new Set(selected);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-slate-200">
+        <thead className="bg-slate-50">
+          <tr>
+            <th className="whitespace-nowrap px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Feature
+            </th>
+            {visibleColumns.map((column) => (
+              <th
+                key={column.slot}
+                className="whitespace-nowrap px-6 py-3 text-center text-xs font-semibold uppercase tracking-wide text-slate-500"
+              >
+                {column.label}
+              </th>
+            ))}
+            {showExtras && (
+              <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Other</th>
+            )}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 bg-white">
+          {groups.map((group) => {
+            const viewGlobalId = group.slots.viewGlobal?.id;
+            const viewOwnId = group.slots.viewOwn?.id;
+            const viewGlobalSelected = viewGlobalId ? selectedSet.has(viewGlobalId) : false;
+
+            return (
+              <tr key={group.feature}>
+                <td className="whitespace-nowrap px-6 py-4 text-sm font-semibold text-slate-800">{group.feature}</td>
+                {visibleColumns.map((column) => {
+                  const option = group.slots[column.slot];
+                  if (!option) {
+                    return (
+                      <td key={column.slot} className="px-6 py-4 text-center text-xs text-slate-300">
+                        —
+                      </td>
+                    );
+                  }
+
+                  const checked = selectedSet.has(option.id);
+                  const disableOwn = column.slot === 'viewOwn' && viewGlobalSelected;
+
+                  return (
+                    <td key={column.slot} className="px-6 py-4 text-center">
+                      <label className="inline-flex items-center justify-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary disabled:cursor-not-allowed"
+                          checked={checked}
+                          disabled={disableOwn}
+                          onChange={(event) =>
+                            onToggle(option.id, event.target.checked, {
+                              deselect:
+                                event.target.checked && column.slot === 'viewGlobal' && viewOwnId
+                                  ? [viewOwnId]
+                                  : undefined
+                            })
+                          }
+                        />
+                        <span className="sr-only">{`${group.feature} – ${column.label}`}</span>
+                      </label>
+                    </td>
+                  );
+                })}
+                {showExtras && (
+                  <td className="px-6 py-4">
+                    {group.extras.length ? (
+                      <div className="space-y-2">
+                        {group.extras.map((option) => {
+                          const checked = selectedSet.has(option.id);
+                          return (
+                            <label
+                              key={option.id}
+                              className="flex items-start gap-3 rounded-md border border-slate-200 p-3 transition hover:border-slate-300"
+                            >
+                              <input
+                                type="checkbox"
+                                className="mt-1 h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                                checked={checked}
+                                onChange={(event) => onToggle(option.id, event.target.checked)}
+                              />
+                              <span className="text-sm text-slate-600">
+                                <span className="block font-medium text-slate-700">{option.label}</span>
+                                <span className="text-xs uppercase tracking-wide text-slate-400">{option.key}</span>
+                              </span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <span className="block text-center text-xs text-slate-300">—</span>
+                    )}
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const PencilIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+    <path d="M15.414 2.586a2 2 0 0 0-2.828 0L3 12.172V17h4.828l9.586-9.586a2 2 0 0 0 0-2.828l-2-2Zm-2.121 1.415 2 2L13 8.293l-2-2 2.293-2.292ZM5 13.414 11.293 7.12l1.586 1.586L6.586 15H5v-1.586Z" />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    className="h-4 w-4"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M10 11v6" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M14 11v6" />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 7V4h6v3m2 0v12a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V7h12Z"
+    />
+  </svg>
+);
 
 const RolesPage = () => {
-  const { data: roles, refetch: refetchRoles } = useQuery(['roles'], async () => {
-    const { data } = await api.get<Pagination<Role>>('/roles');
-    return data.content;
-  });
-
-  const { data: permissions } = useQuery(['permissions'], async () => {
-    const { data } = await api.get<Pagination<Permission>>('/permissions?size=100');
-    return data.content;
-  });
-
-  const [roleForm, setRoleForm] = useState({ key: '', name: '' });
-  const [selectedRole, setSelectedRole] = useState<number | null>(null);
-  const [selectedPermissions, setSelectedPermissions] = useState<number[]>([]);
-
-  const createRole = useMutation(
-    async () => {
-      await api.post('/roles', roleForm);
-    },
-    {
-      onSuccess: () => {
-        setRoleForm({ key: '', name: '' });
-        refetchRoles();
-      }
-    }
+  const { notify } = useToast();
+  const { permissions: authPermissions } = useAppSelector((state) => state.auth);
+  const grantedPermissions = (authPermissions ?? []) as PermissionKey[];
+  const canExportRoles = useMemo(
+    () => hasAnyPermission(grantedPermissions, ['ROLES_EXPORT']),
+    [grantedPermissions]
   );
 
-  const assignPermissions = useMutation(
-    async () => {
-      if (!selectedRole) return;
-      await api.post(`/roles/${selectedRole}/permissions`, { permissionIds: selectedPermissions });
-    },
-    {
-      onSuccess: () => {
-        setSelectedPermissions([]);
-        refetchRoles();
-      }
+  const [view, setView] = useState<DirectoryView>('list');
+  const [pageSize, setPageSize] = useState(25);
+  const [page, setPage] = useState(0);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'all' | 'internal' | 'customer'>('all');
+  const [permissionFilter, setPermissionFilter] = useState<'all' | 'with' | 'without'>('all');
+  const [roleName, setRoleName] = useState('');
+  const [roleKey, setRoleKey] = useState('');
+  const [keyTouched, setKeyTouched] = useState(false);
+  const [rolePermissions, setRolePermissions] = useState<number[]>([]);
+  const [sort, setSort] = useState<{ field: RoleSortField; direction: 'asc' | 'desc' }>({
+    field: 'name',
+    direction: 'asc'
+  });
+  const [editingRole, setEditingRole] = useState<Role | null>(null);
+  const [editForm, setEditForm] = useState({ name: '', key: '' });
+  const [editingPermissions, setEditingPermissions] = useState<number[]>([]);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearchTerm(searchDraft.trim());
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [pageSize, typeFilter, permissionFilter, searchTerm, sort.field, sort.direction]);
+
+  useEffect(() => {
+    if (!keyTouched) {
+      setRoleKey(formatRoleKey(roleName));
     }
+  }, [roleName, keyTouched]);
+
+  const rolesResponse = useQuery<Pagination<Role>>({
+    queryKey: ['roles', page, pageSize, sort.field, sort.direction],
+    queryFn: async () => {
+      const serverSortField = sort.field === 'key' ? 'key' : 'name';
+      const direction = serverSortField === sort.field ? sort.direction : 'asc';
+      const params = new URLSearchParams({
+        page: String(page),
+        size: String(pageSize),
+        sort: serverSortField,
+        direction
+      });
+      const { data } = await api.get<Pagination<Role>>(`/roles?${params.toString()}`);
+      return data;
+    }
+  });
+
+  const {
+    data: permissions = []
+  } = useQuery<Permission[]>({
+    queryKey: ['permissions', 'options'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Permission>>('/permissions?size=500');
+      return data.content;
+    }
+  });
+
+  const permissionGroups = useMemo(() => buildPermissionGroups(permissions), [permissions]);
+  const permissionLookup = useMemo(() => {
+    const lookup = new Map<string, Permission>();
+    permissions.forEach((permission) => lookup.set(permission.key, permission));
+    return lookup;
+  }, [permissions]);
+
+  const roles = rolesResponse.data?.content ?? [];
+  const totalElements = rolesResponse.data?.totalElements ?? roles.length;
+  const totalPages = rolesResponse.data?.totalPages ?? 1;
+
+  useEffect(() => {
+    if (!rolesResponse.data) {
+      return;
+    }
+    const pages = rolesResponse.data.totalPages;
+    if (pages === 0 && page !== 0) {
+      setPage(0);
+      return;
+    }
+    if (pages > 0 && page >= pages) {
+      setPage(pages - 1);
+    }
+  }, [rolesResponse.data, page]);
+
+  useEffect(() => {
+    if (view === 'create') {
+      setRoleName('');
+      setRoleKey('');
+      setKeyTouched(false);
+      setRolePermissions([]);
+      setCreateError(null);
+    }
+  }, [view]);
+
+  useEffect(() => {
+    if (!editingRole) {
+      setEditForm({ name: '', key: '' });
+      setEditingPermissions([]);
+      return;
+    }
+    setEditForm({ name: editingRole.name, key: editingRole.key });
+    if (permissions.length) {
+      const ids = permissions
+        .filter((permission) => editingRole.permissions.includes(permission.key as PermissionKey))
+        .map((permission) => permission.id);
+      setEditingPermissions(ids);
+    } else {
+      setEditingPermissions([]);
+    }
+  }, [editingRole, permissions]);
+
+  const handleSortChange = (field: RoleSortField) => {
+    setSort((prev) => {
+      if (prev.field === field) {
+        return { field, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { field, direction: 'asc' };
+    });
+  };
+
+  const applyRoleFilters = (list: Role[]) => {
+    const term = searchTerm.toLowerCase();
+    return list.filter((role) => {
+      if (typeFilter === 'customer' && !isCustomerRole(role)) {
+        return false;
+      }
+      if (typeFilter === 'internal' && isCustomerRole(role)) {
+        return false;
+      }
+      if (permissionFilter === 'with' && role.permissions.length === 0) {
+        return false;
+      }
+      if (permissionFilter === 'without' && role.permissions.length > 0) {
+        return false;
+      }
+      if (!term) {
+        return true;
+      }
+      const permissionMatches = role.permissions.some((permissionKey) =>
+        (permissionLookup.get(permissionKey)?.name ?? permissionKey).toLowerCase().includes(term)
+      );
+      return (
+        role.name.toLowerCase().includes(term) ||
+        role.key.toLowerCase().includes(term) ||
+        permissionMatches
+      );
+    });
+  };
+
+  const sortRolesList = (list: Role[]) => {
+    const copy = [...list];
+    const factor = sort.direction === 'asc' ? 1 : -1;
+    copy.sort((a, b) => {
+      switch (sort.field) {
+        case 'key':
+          return compareText(a.key, b.key) * factor;
+        case 'audience': {
+          const diff = (isCustomerRole(a) ? 1 : 0) - (isCustomerRole(b) ? 1 : 0);
+          if (diff === 0) {
+            return compareText(a.name, b.name) * factor;
+          }
+          return diff * factor;
+        }
+        case 'permissionCount': {
+          const diff = a.permissions.length - b.permissions.length;
+          if (diff === 0) {
+            return compareText(a.name, b.name) * factor;
+          }
+          return diff * factor;
+        }
+        case 'name':
+        default:
+          return compareText(a.name, b.name) * factor;
+      }
+    });
+    return copy;
+  };
+
+  const filteredRoles = useMemo(
+    () => applyRoleFilters(roles),
+    [roles, searchTerm, permissionLookup, typeFilter, permissionFilter]
   );
 
-  const roleOptions = useMemo(() => roles ?? [], [roles]);
+  const sortedRoles = useMemo(() => sortRolesList(filteredRoles), [filteredRoles, sort]);
+
+  const fetchAllRoles = async (): Promise<Role[]> => {
+    const serverSortField = sort.field === 'key' ? 'key' : 'name';
+    const direction = serverSortField === sort.field ? sort.direction : 'asc';
+    const size = 200;
+    const baseParams: Record<string, unknown> = {
+      size,
+      sort: serverSortField,
+      direction
+    };
+    const aggregated: Role[] = [];
+    let pageIndex = 0;
+    let totalPagesCount = 1;
+
+    do {
+      const params = { ...baseParams, page: pageIndex };
+      const { data } = await api.get<Pagination<Role>>('/roles', { params });
+      aggregated.push(...(data.content ?? []));
+      totalPagesCount = data.totalPages ?? 1;
+      pageIndex += 1;
+      if (pageIndex >= totalPagesCount) {
+        break;
+      }
+    } while (pageIndex < totalPagesCount && pageIndex < 50);
+
+    return aggregated;
+  };
+
+  const handleExportRoles = async (format: ExportFormat) => {
+    if (!canExportRoles || isExporting) {
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const allRoles = await fetchAllRoles();
+      const filtered = applyRoleFilters(allRoles);
+      const sorted = sortRolesList(filtered);
+      if (!sorted.length) {
+        notify({ type: 'error', message: 'There are no roles to export for the current filters.' });
+        return;
+      }
+      const columns = [
+        { key: 'name', header: 'Name' },
+        { key: 'key', header: 'Key' },
+        { key: 'audience', header: 'Audience' },
+        { key: 'permissionCount', header: 'Permission Count' },
+        { key: 'permissionList', header: 'Permission Keys' }
+      ];
+      const rows = sorted.map((role) => ({
+        name: role.name,
+        key: role.key,
+        audience: isCustomerRole(role) ? 'Customer' : 'Internal',
+        permissionCount: role.permissions.length,
+        permissionList: role.permissions.length ? role.permissions.join(', ') : '—'
+      }));
+      exportDataset({
+        format,
+        columns,
+        rows,
+        fileName: 'roles',
+        title: 'Roles'
+      });
+    } catch (error) {
+      notify({ type: 'error', message: 'Unable to export roles. Please try again.' });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const metrics = useMemo(() => {
+    const customerCount = roles.filter(isCustomerRole).length;
+    const withPermissions = roles.filter((role) => role.permissions.length > 0).length;
+    const total = totalElements;
+    const internalCount = Math.max(total - customerCount, 0);
+    return { total, withPermissions, customerCount, internalCount };
+  }, [roles, totalElements]);
+
+  const togglePermission = (
+    id: number,
+    checked: boolean,
+    setter: Dispatch<SetStateAction<number[]>>,
+    options: ToggleOptions = {}
+  ) => {
+    setter((prev) => {
+      let next = [...prev];
+
+      if (checked) {
+        if (!next.includes(id)) {
+          next.push(id);
+        }
+      } else {
+        next = next.filter((permissionId) => permissionId !== id);
+      }
+
+      if (options.deselect?.length) {
+        const deselectSet = new Set(options.deselect);
+        next = next.filter((permissionId) => !deselectSet.has(permissionId));
+      }
+
+      if (options.select?.length) {
+        const set = new Set(next);
+        options.select.forEach((permissionId) => set.add(permissionId));
+        next = Array.from(set);
+      }
+
+      return next;
+    });
+  };
+
+  const { refetch: refetchRoles } = rolesResponse;
+
+  const createRole = useMutation({
+    mutationFn: async (payload: { key: string; name: string; permissionIds: number[] }) => {
+      const { data } = await api.post<Role>('/roles', { key: payload.key, name: payload.name });
+      if (payload.permissionIds.length) {
+        await api.post(`/roles/${data.id}/permissions`, { permissionIds: payload.permissionIds });
+      }
+      return data;
+    },
+    onSuccess: () => {
+      setView('list');
+      setCreateError(null);
+      refetchRoles();
+      notify({ type: 'success', message: 'Role created successfully.' });
+    },
+    onError: (error) => {
+      const message = getErrorMessage(error);
+      setCreateError(message);
+      notify({ type: 'error', message });
+    }
+  });
+
+  const updateRole = useMutation({
+    mutationFn: async (payload: { id: number; key: string; name: string; permissionIds: number[] }) => {
+      await api.put(`/roles/${payload.id}`, { key: payload.key, name: payload.name });
+      await api.post(`/roles/${payload.id}/permissions`, { permissionIds: payload.permissionIds });
+    },
+    onSuccess: () => {
+      setEditingRole(null);
+      setView('list');
+      setEditError(null);
+      refetchRoles();
+      notify({ type: 'success', message: 'Role updated successfully.' });
+    },
+    onError: (error) => {
+      const message = getErrorMessage(error);
+      setEditError(message);
+      notify({ type: 'error', message });
+    }
+  });
+
+  const deleteRole = useMutation({
+    mutationFn: async (id: number) => {
+      await api.delete(`/roles/${id}`);
+    },
+    onSuccess: () => {
+      if (editingRole) {
+        setEditingRole(null);
+        setView('list');
+      }
+      refetchRoles();
+      notify({ type: 'success', message: 'Role deleted.' });
+    },
+    onError: (error) => {
+      notify({ type: 'error', message: getErrorMessage(error) });
+    }
+  });
 
   const handleCreate = (event: FormEvent) => {
     event.preventDefault();
-    createRole.mutate();
+    const formattedKey = roleKey || formatRoleKey(roleName);
+    const trimmedName = roleName.trim();
+    if (!formattedKey || !trimmedName) {
+      setCreateError('Role name and key are required.');
+      notify({ type: 'error', message: 'Role name and key are required.' });
+      return;
+    }
+
+    setCreateError(null);
+    createRole.mutate({ key: formattedKey, name: trimmedName, permissionIds: rolePermissions });
   };
 
-  const handleAssign = (event: FormEvent) => {
+  const handleUpdate = (event: FormEvent) => {
     event.preventDefault();
-    assignPermissions.mutate();
+    if (!editingRole) {
+      return;
+    }
+    const formattedKey = editForm.key || editingRole.key;
+    const trimmedName = editForm.name.trim();
+    if (!trimmedName) {
+      setEditError('Role name is required.');
+      notify({ type: 'error', message: 'Role name is required.' });
+      return;
+    }
+    setEditError(null);
+    updateRole.mutate({
+      id: editingRole.id,
+      key: formatRoleKey(formattedKey),
+      name: trimmedName,
+      permissionIds: editingPermissions
+    });
   };
+
+  const handleDelete = (role: Role) => {
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm(`Delete the role “${role.name}”?`);
+      if (!confirmed) {
+        return;
+      }
+    }
+    deleteRole.mutate(role.id);
+  };
+
+  const renderPermissionSummary = (role: Role) => {
+    if (!role.permissions.length) {
+      return 'No permissions yet';
+    }
+    const labels = role.permissions.map((permissionKey) => {
+      const permission = permissionLookup.get(permissionKey);
+      if (permission?.name) {
+        return permission.name;
+      }
+      return toTitleCase(permissionKey.toLowerCase());
+    });
+
+    if (labels.length <= 3) {
+      return labels.join(', ');
+    }
+
+    return `${labels.slice(0, 3).join(', ')} +${labels.length - 3} more`;
+  };
+
+  const renderSummaryCards = () => (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total roles</p>
+        <p className="mt-2 text-3xl font-semibold text-slate-800">{metrics.total}</p>
+        <p className="mt-1 text-xs text-slate-500">Across internal teams and customer accounts.</p>
+      </div>
+      <div className="rounded-2xl border border-emerald-100 bg-emerald-50/60 p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Assignable</p>
+        <p className="mt-2 text-3xl font-semibold text-emerald-700">{metrics.withPermissions}</p>
+        <p className="mt-1 text-xs text-emerald-600">Roles that currently grant at least one permission.</p>
+      </div>
+      <div className="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">Internal</p>
+        <p className="mt-2 text-3xl font-semibold text-indigo-700">{metrics.internalCount}</p>
+        <p className="mt-1 text-xs text-indigo-600">Designed for internal staff and operations.</p>
+      </div>
+      <div className="rounded-2xl border border-blue-100 bg-blue-50/60 p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">Customer</p>
+        <p className="mt-2 text-3xl font-semibold text-blue-700">{metrics.customerCount}</p>
+        <p className="mt-1 text-xs text-blue-600">Shared with customer-facing collaborators.</p>
+      </div>
+    </div>
+  );
+
+  const renderFilters = () => (
+    <div className="flex flex-col gap-4 border-b border-slate-200 px-6 py-4 lg:flex-row lg:items-end">
+      <div className="flex-1">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Search</label>
+        <input
+          type="search"
+          value={searchDraft}
+          onChange={(event) => setSearchDraft(event.target.value)}
+          placeholder="Search by role name, key, or permission"
+          className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+        />
+      </div>
+      <div className="grid w-full gap-4 sm:grid-cols-2 lg:w-auto lg:flex lg:items-end lg:gap-4">
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Audience</label>
+          <select
+            value={typeFilter}
+            onChange={(event) => setTypeFilter(event.target.value as typeof typeFilter)}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          >
+            <option value="all">All</option>
+            <option value="internal">Internal</option>
+            <option value="customer">Customer</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Permissions</label>
+          <select
+            value={permissionFilter}
+            onChange={(event) => setPermissionFilter(event.target.value as typeof permissionFilter)}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          >
+            <option value="all">All</option>
+            <option value="with">Has permissions</option>
+            <option value="without">No permissions</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Rows</label>
+          <select
+            value={pageSize}
+            onChange={(event) => setPageSize(Number(event.target.value))}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          >
+            {[10, 25, 50, 100].map((size) => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderTable = () => (
+    <div className="flex flex-col">
+      {renderFilters()}
+      <div className="flex-1 overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200">
+          <thead className="bg-slate-50">
+            <tr>
+              <SortableColumnHeader
+                label="Role"
+                field="name"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <SortableColumnHeader
+                label="Key"
+                field="key"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <SortableColumnHeader
+                label="Audience"
+                field="audience"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <SortableColumnHeader
+                label="Permissions"
+                field="permissionCount"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 bg-white">
+            {rolesResponse.isLoading ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500">
+                  Loading roles…
+                </td>
+              </tr>
+            ) : sortedRoles.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-sm text-slate-500">
+                  No roles match the current filters.
+                </td>
+              </tr>
+            ) : (
+              sortedRoles.map((role) => (
+                <tr key={role.id} className="transition hover:bg-blue-50/40">
+                  <td className="px-4 py-3">
+                    <div className="text-sm font-semibold text-slate-800">{role.name}</div>
+                  </td>
+                  <td className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">{role.key}</td>
+                  <td className="px-4 py-3 text-sm text-slate-600">{isCustomerRole(role) ? 'Customer' : 'Internal'}</td>
+                  <td className="px-4 py-3 text-sm text-slate-600">{renderPermissionSummary(role)}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditingRole(role);
+                          setView('edit');
+                        }}
+                        className="rounded-full border border-slate-200 p-2 text-slate-500 transition hover:border-slate-300 hover:text-slate-800"
+                        aria-label={`Edit ${role.name}`}
+                      >
+                        <PencilIcon />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleDelete(role)}
+                        className="rounded-full border border-rose-200 p-2 text-rose-500 transition hover:border-rose-300 hover:text-rose-600"
+                        aria-label={`Delete ${role.name}`}
+                        disabled={deleteRole.isPending}
+                      >
+                        <TrashIcon />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+          <tfoot className="bg-slate-50">
+            <tr>
+              <td colSpan={5} className="px-4 py-3">
+                <div className="flex flex-col gap-3 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between">
+                  <span>
+                    Showing {sortedRoles.length} of {totalElements} role{totalElements === 1 ? '' : 's'}
+                  </span>
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+                      className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm text-slate-600 transition hover:border-slate-400 hover:text-slate-800 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                      disabled={page === 0}
+                    >
+                      Previous
+                    </button>
+                    <span>
+                      Page {page + 1} of {totalPages}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => setPage((prev) => (prev + 1 < totalPages ? prev + 1 : prev))}
+                      className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm text-slate-600 transition hover:border-slate-400 hover:text-slate-800 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                      disabled={page + 1 >= totalPages}
+                    >
+                      Next
+                    </button>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+
+  const isListView = view === 'list';
+  const isCreateView = view === 'create';
+  const isEditView = view === 'edit';
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-slate-800">Roles & Permissions</h1>
-
-      <form onSubmit={handleCreate} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-        <h2 className="text-lg font-semibold text-slate-700">Create role</h2>
-        <div className="mt-4 grid gap-4 sm:grid-cols-2">
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Key</label>
-            <input
-              type="text"
-              value={roleForm.key}
-              onChange={(e) => setRoleForm((prev) => ({ ...prev, key: e.target.value }))}
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Name</label>
-            <input
-              type="text"
-              value={roleForm.name}
-              onChange={(e) => setRoleForm((prev) => ({ ...prev, name: e.target.value }))}
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-              required
-            />
-          </div>
+    <div className="flex min-h-full flex-col gap-6 px-6 py-6">
+      <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">Roles</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Design and manage reusable permission bundles to keep access aligned with your operating model.
+          </p>
         </div>
-        <button
-          type="submit"
-          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-          disabled={createRole.isLoading}
-        >
-          {createRole.isLoading ? 'Saving...' : 'Create role'}
-        </button>
-      </form>
-
-      <form onSubmit={handleAssign} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-        <h2 className="text-lg font-semibold text-slate-700">Assign permissions</h2>
-        <div className="mt-4 grid gap-4 sm:grid-cols-2">
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Role</label>
-            <select
-              value={selectedRole ?? ''}
-              onChange={(e) => setSelectedRole(Number(e.target.value))}
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-              required
+        {isListView ? (
+          <div className="flex flex-wrap items-center gap-3">
+            {canExportRoles && (
+              <ExportMenu
+                onSelect={handleExportRoles}
+                disabled={rolesResponse.isLoading}
+                isBusy={isExporting}
+              />
+            )}
+            <button
+              type="button"
+              onClick={() => setView('create')}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-600"
             >
-              <option value="" disabled>
-                Select role
-              </option>
-              {roleOptions.map((role) => (
-                <option key={role.id} value={role.id}>
-                  {role.name}
-                </option>
-              ))}
-            </select>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.6}
+                className="h-4 w-4"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m6-6H6" />
+              </svg>
+              New role
+            </button>
           </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Permissions</label>
-            <select
-              multiple
-              value={selectedPermissions.map(String)}
-              onChange={(e) => {
-                const values = Array.from(e.target.selectedOptions).map((option) => Number(option.value));
-                setSelectedPermissions(values);
-              }}
-              className="mt-1 h-40 w-full rounded-md border border-slate-300 px-3 py-2"
-              required
-            >
-              {permissions?.map((permission) => (
-                <option key={permission.id} value={permission.id}>
-                  {permission.name}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-        <button
-          type="submit"
-          className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-          disabled={assignPermissions.isLoading}
-        >
-          {assignPermissions.isLoading ? 'Assigning...' : 'Assign permissions'}
-        </button>
-      </form>
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setView('list');
+              setEditingRole(null);
+            }}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 hover:text-slate-800"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="h-4 w-4">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+            </svg>
+            Back to roles
+          </button>
+        )}
+      </div>
 
-      <DataTable title="Roles">
-        <thead>
-          <tr>
-            <th className="px-3 py-2 text-left">Key</th>
-            <th className="px-3 py-2 text-left">Name</th>
-            <th className="px-3 py-2 text-left">Permissions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {roles?.map((role) => (
-            <tr key={role.id} className="border-t border-slate-200">
-              <td className="px-3 py-2 uppercase tracking-wide text-slate-500">{role.key}</td>
-              <td className="px-3 py-2">{role.name}</td>
-              <td className="px-3 py-2 text-sm text-slate-600">{role.permissions.join(', ')}</td>
-            </tr>
-          ))}
-        </tbody>
-      </DataTable>
+      {isListView ? (
+        <>
+          {renderSummaryCards()}
+          <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">{renderTable()}</div>
+        </>
+      ) : isCreateView ? (
+        <form onSubmit={handleCreate} className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex flex-col gap-3 border-b border-slate-200 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-800">Create role</h2>
+              <p className="text-sm text-slate-500">Give the role a friendly name and choose the permissions it should grant.</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setView('list')}
+                className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={createRole.isPending}
+              >
+                {createRole.isPending ? 'Saving…' : 'Save role'}
+              </button>
+            </div>
+          </div>
+
+          {(createError || createRole.isError) && (
+            <div className="mx-6 mt-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-600">
+              {createError ?? getErrorMessage(createRole.error)}
+            </div>
+          )}
+
+          <div className="space-y-6 px-6 py-6">
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-slate-700">Role name</label>
+                <input
+                  type="text"
+                  value={roleName}
+                  onChange={(event) => setRoleName(event.target.value)}
+                  placeholder="e.g. Sales Manager"
+                  required
+                  className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700">Role key</label>
+                <input
+                  type="text"
+                  value={roleKey}
+                  onChange={(event) => {
+                    setRoleKey(formatRoleKey(event.target.value));
+                    setKeyTouched(true);
+                  }}
+                  placeholder="SALES_MANAGER"
+                  required
+                  className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm uppercase focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+                <p className="mt-1 text-xs text-slate-500">This identifier must be unique and is used by the API.</p>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200">
+              <div className="border-b border-slate-200 px-6 py-4">
+                <h3 className="text-base font-semibold text-slate-800">Permission catalogue</h3>
+                <p className="text-sm text-slate-500">Select the features and capabilities that this role should unlock.</p>
+              </div>
+              <PermissionMatrix
+                groups={permissionGroups}
+                selected={rolePermissions}
+                onToggle={(id, checked, options) => togglePermission(id, checked, setRolePermissions, options)}
+              />
+            </div>
+          </div>
+        </form>
+      ) : isEditView && editingRole ? (
+        <form onSubmit={handleUpdate} className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex flex-col gap-3 border-b border-slate-200 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-800">Edit {editingRole.name}</h2>
+              <p className="text-sm text-slate-500">Update the role details and adjust the permissions it grants.</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingRole(null);
+                  setView('list');
+                }}
+                className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={updateRole.isPending}
+              >
+                {updateRole.isPending ? 'Saving…' : 'Save changes'}
+              </button>
+            </div>
+          </div>
+
+          {(editError || updateRole.isError) && (
+            <div className="mx-6 mt-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-600">
+              {editError ?? getErrorMessage(updateRole.error)}
+            </div>
+          )}
+
+          <div className="space-y-6 px-6 py-6">
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-slate-700">Role name</label>
+                <input
+                  type="text"
+                  value={editForm.name}
+                  onChange={(event) => setEditForm((prev) => ({ ...prev, name: event.target.value }))}
+                  required
+                  className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700">Role key</label>
+                <input
+                  type="text"
+                  value={editForm.key}
+                  onChange={(event) => setEditForm((prev) => ({ ...prev, key: formatRoleKey(event.target.value) }))}
+                  required
+                  className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm uppercase focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200">
+              <div className="border-b border-slate-200 px-6 py-4">
+                <h4 className="text-base font-semibold text-slate-800">Permissions</h4>
+                <p className="text-sm text-slate-500">Adjust the capabilities granted to this role.</p>
+              </div>
+              <PermissionMatrix
+                groups={permissionGroups}
+                selected={editingPermissions}
+                onToggle={(id, checked, options) => togglePermission(id, checked, setEditingPermissions, options)}
+              />
+            </div>
+          </div>
+        </form>
+      ) : null}
     </div>
   );
 };

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,125 +1,1432 @@
-import { FormEvent, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '../services/http';
-import DataTable from '../components/DataTable';
-import type { Pagination, User } from '../types/models';
+import type { Pagination, Permission, Role, User, UserSummaryMetrics } from '../types/models';
+import { useToast } from '../components/ToastProvider';
+import SortableColumnHeader from '../components/SortableColumnHeader';
+import ExportMenu from '../components/ExportMenu';
+import { exportDataset, type ExportFormat } from '../utils/exporters';
+import { extractErrorMessage } from '../utils/errors';
+import { buildPermissionGroups, CAPABILITY_COLUMNS, type PermissionGroup } from '../utils/permissionGroups';
 import { useAppSelector } from '../app/hooks';
 import type { PermissionKey } from '../types/auth';
+import { hasAnyPermission } from '../utils/permissions';
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+const DEFAULT_PAGE_SIZE = 25;
+const CUSTOMER_ROLE_KEY = 'CUSTOMER';
+
+const SLOT_LABELS = CAPABILITY_COLUMNS.reduce<Record<string, string>>((map, column) => {
+  map[column.slot] = column.label;
+  return map;
+}, {});
+
+const PencilIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+    <path d="M15.414 2.586a2 2 0 0 0-2.828 0L3 12.172V17h4.828l9.586-9.586a2 2 0 0 0 0-2.828l-2-2Zm-2.121 1.415 2 2L13 8.293l-2-2 2.293-2.292ZM5 13.414 11.293 7.12l1.586 1.586L6.586 15H5v-1.586Z" />
+  </svg>
+);
+
+const TrashIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    className="h-4 w-4"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M10 11v6" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M14 11v6" />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 7V4h6v3m2 0v12a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V7h12Z"
+    />
+  </svg>
+);
+
+type PanelMode = 'empty' | 'create' | 'detail';
+type DetailTab = 'profile' | 'access';
+type UserSortField = 'name' | 'email' | 'status' | 'audience' | 'groups';
+
+type UserFormState = {
+  fullName: string;
+  email: string;
+  password: string;
+  active: boolean;
+  roleIds: number[];
+  directPermissions: string[];
+  revokedPermissions: string[];
+};
+
+const emptyForm: UserFormState = {
+  fullName: '',
+  email: '',
+  password: '',
+  active: true,
+  roleIds: [],
+  directPermissions: [],
+  revokedPermissions: []
+};
+
+const normalizePermissionKey = (value: string) => value.toUpperCase();
+
+const compareText = (a: string, b: string) => a.localeCompare(b, undefined, { sensitivity: 'base' });
+
+const isCustomerAccount = (user: User) =>
+  user.roles.some((role) => role.toUpperCase() === CUSTOMER_ROLE_KEY);
 
 const UsersPage = () => {
-  const { permissions } = useAppSelector((state) => state.auth);
-  const canCreate = (permissions as PermissionKey[]).includes('USER_CREATE');
-  const canDelete = (permissions as PermissionKey[]).includes('USER_DELETE');
+  const queryClient = useQueryClient();
+  const { notify } = useToast();
+  const { permissions: grantedPermissions, user: currentUser, roles: currentRoles } = useAppSelector((state) => state.auth);
 
-  const [form, setForm] = useState({ email: '', fullName: '', password: '' });
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'inactive'>('all');
+  const [audienceFilter, setAudienceFilter] = useState<'all' | 'internal' | 'customer'>('all');
+  const [panelMode, setPanelMode] = useState<PanelMode>('empty');
+  const [activeTab, setActiveTab] = useState<DetailTab>('profile');
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+  const [form, setForm] = useState<UserFormState>(emptyForm);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [statusUpdateId, setStatusUpdateId] = useState<number | null>(null);
+  const [sort, setSort] = useState<{ field: UserSortField; direction: 'asc' | 'desc' }>({ field: 'name', direction: 'asc' });
+  const [isExporting, setIsExporting] = useState(false);
+  const currentUserId = currentUser?.id ?? null;
+  const isSuperAdmin = useMemo(
+    () => (currentRoles ?? []).some((role) => role.toUpperCase() === 'SUPER_ADMIN'),
+    [currentRoles]
+  );
 
-  const { data, refetch } = useQuery(['users', 'list'], async () => {
-    const { data: response } = await api.get<Pagination<User>>('/users');
-    return response.content;
+  const canCreateUser = useMemo(
+    () => hasAnyPermission(grantedPermissions as PermissionKey[], ['USER_CREATE', 'CUSTOMER_CREATE']),
+    [grantedPermissions]
+  );
+  const canManageUsers = useMemo(
+    () => hasAnyPermission(grantedPermissions as PermissionKey[], ['USER_UPDATE', 'CUSTOMER_UPDATE']),
+    [grantedPermissions]
+  );
+  const canDeleteUsers = useMemo(
+    () => hasAnyPermission(grantedPermissions as PermissionKey[], ['USER_DELETE', 'CUSTOMER_DELETE']),
+    [grantedPermissions]
+  );
+  const canExportUsers = useMemo(
+    () => hasAnyPermission(grantedPermissions as PermissionKey[], ['USERS_EXPORT']),
+    [grantedPermissions]
+  );
+
+  useEffect(() => {
+    setPage(0);
+  }, [pageSize, statusFilter, audienceFilter, sort.field, sort.direction]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearchTerm(searchDraft.trim());
+      setPage(0);
+    }, 300);
+
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  useEffect(() => {
+    if (panelMode === 'create') {
+      setForm(emptyForm);
+      setFormError(null);
+      setActiveTab('profile');
+      setSelectedUserId(null);
+    }
+  }, [panelMode]);
+
+  const { data: roles = [] } = useQuery<Role[]>({
+    queryKey: ['roles', 'options'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Role>>('/roles', { params: { size: 200 } });
+      return data.content;
+    }
   });
 
-  const createUser = useMutation(
-    async () => {
-      await api.post('/users', { ...form, roleIds: [] });
-    },
-    {
-      onSuccess: () => {
-        setForm({ email: '', fullName: '', password: '' });
-        refetch();
+  const { data: permissionsCatalog = [] } = useQuery<Permission[]>({
+    queryKey: ['permissions', 'catalogue'],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<Permission>>('/permissions', { params: { size: 500 } });
+      return data.content;
+    }
+  });
+
+  const permissionGroups = useMemo<PermissionGroup[]>(
+    () => buildPermissionGroups(permissionsCatalog),
+    [permissionsCatalog]
+  );
+
+  const permissionLookup = useMemo(() => {
+    const map = new Map<string, Permission>();
+    permissionsCatalog.forEach((permission) => map.set(permission.key.toUpperCase(), permission));
+    return map;
+  }, [permissionsCatalog]);
+
+  const roleIdByKey = useMemo(() => {
+    const map = new Map<string, number>();
+    roles.forEach((role) => map.set(role.key.toUpperCase(), role.id));
+    return map;
+  }, [roles]);
+
+  const summaryQuery = useQuery<UserSummaryMetrics>({
+    queryKey: ['users', 'summary'],
+    queryFn: async () => {
+      const { data } = await api.get<UserSummaryMetrics>('/users/summary');
+      return data;
+    }
+  });
+
+  const usersQuery = useQuery<Pagination<User>>({
+    queryKey: ['users', 'list', { page, pageSize, searchTerm, sortField: sort.field, sortDirection: sort.direction }],
+    queryFn: async () => {
+      const serverSortable: UserSortField[] = ['name', 'email', 'status'];
+      const serverSortField = serverSortable.includes(sort.field) ? sort.field : 'name';
+      const params: Record<string, unknown> = {
+        page,
+        size: pageSize,
+        sort: serverSortField,
+        direction: serverSortField === sort.field ? sort.direction : 'asc'
+      };
+      if (searchTerm.trim()) {
+        params.search = searchTerm.trim();
       }
-    }
-  );
-
-  const deleteUser = useMutation<void, unknown, number>(
-    async (id: number) => {
-      await api.delete(`/users/${id}`);
+      const { data } = await api.get<Pagination<User>>('/users', { params });
+      return data;
     },
-    {
-      onSuccess: () => refetch()
-    }
-  );
+    placeholderData: (previousData) => previousData
+  });
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    createUser.mutate();
+  const selectedUserQuery = useQuery<User>({
+    queryKey: ['users', 'detail', selectedUserId],
+    queryFn: async () => {
+      const { data } = await api.get<User>(`/users/${selectedUserId}`);
+      return data;
+    },
+    enabled: panelMode === 'detail' && selectedUserId !== null
+  });
+
+  useEffect(() => {
+    if (panelMode === 'detail' && selectedUserQuery.data) {
+      const detail = selectedUserQuery.data;
+      const assignedRoleIds = detail.roles
+        .map((roleKey) => roleIdByKey.get(roleKey.toUpperCase()))
+        .filter((value): value is number => typeof value === 'number');
+      const roleDerivedPermissions = new Set<string>();
+      roles.forEach((role) => {
+        if (assignedRoleIds.includes(role.id)) {
+          role.permissions?.forEach((permission) => {
+            roleDerivedPermissions.add(normalizePermissionKey(permission));
+          });
+        }
+      });
+      const sanitizedDirect = (detail.directPermissions ?? [])
+        .map(normalizePermissionKey)
+        .filter((permissionKey) => !roleDerivedPermissions.has(permissionKey));
+      const sanitizedRevoked = (detail.revokedPermissions ?? [])
+        .map(normalizePermissionKey)
+        .filter((permissionKey) => roleDerivedPermissions.has(permissionKey));
+      setForm({
+        fullName: detail.fullName,
+        email: detail.email,
+        password: '',
+        active: detail.active,
+        roleIds: assignedRoleIds,
+        directPermissions: sanitizedDirect,
+        revokedPermissions: sanitizedRevoked
+      });
+      setFormError(null);
+      setActiveTab('profile');
+    }
+  }, [panelMode, selectedUserQuery.data, roleIdByKey, roles]);
+
+  const invalidateUsers = () => {
+    queryClient.invalidateQueries({ queryKey: ['users', 'list'] });
+    queryClient.invalidateQueries({ queryKey: ['users', 'summary'] });
   };
 
-  return (
+  const createUser = useMutation({
+    mutationFn: async () => {
+      const trimmedPassword = form.password.trim();
+      if (trimmedPassword.length < 8) {
+        throw new Error('Password must be at least 8 characters long.');
+      }
+      const { data } = await api.post<User>('/users', {
+        email: form.email,
+        fullName: form.fullName,
+        password: trimmedPassword,
+        active: form.active,
+        roleIds: form.roleIds,
+        permissionKeys: form.directPermissions,
+        revokedPermissionKeys: form.revokedPermissions
+      });
+      return data;
+    },
+    onSuccess: (data) => {
+      notify({ type: 'success', message: 'User created successfully.' });
+      invalidateUsers();
+      setSelectedUserId(data.id);
+      setPanelMode('detail');
+      setActiveTab('profile');
+      setForm({
+        fullName: data.fullName,
+        email: data.email,
+        password: '',
+        active: data.active,
+        roleIds: data.roles
+          .map((roleKey) => roleIdByKey.get(roleKey.toUpperCase()))
+          .filter((value): value is number => typeof value === 'number'),
+        directPermissions: (data.directPermissions ?? []).map(normalizePermissionKey),
+        revokedPermissions: (data.revokedPermissions ?? []).map(normalizePermissionKey)
+      });
+      queryClient.invalidateQueries({ queryKey: ['users', 'detail', data.id] });
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : extractErrorMessage(error, 'Unable to create user.');
+      setFormError(message);
+      notify({ type: 'error', message });
+    }
+  });
+
+  const updateUser = useMutation({
+    mutationFn: async () => {
+      if (!selectedUserId) {
+        return null;
+      }
+      const trimmedPassword = form.password.trim();
+      if (trimmedPassword && trimmedPassword.length < 8) {
+        throw new Error('Password must be at least 8 characters long.');
+      }
+      const { data } = await api.put<User>(`/users/${selectedUserId}`, {
+        email: form.email,
+        fullName: form.fullName,
+        active: form.active,
+        password: trimmedPassword || undefined,
+        roleIds: form.roleIds,
+        permissionKeys: form.directPermissions,
+        revokedPermissionKeys: form.revokedPermissions
+      });
+      return data;
+    },
+    onSuccess: (data) => {
+      if (!data) {
+        return;
+      }
+      notify({ type: 'success', message: 'User updated successfully.' });
+      invalidateUsers();
+      setForm({
+        fullName: data.fullName,
+        email: data.email,
+        password: '',
+        active: data.active,
+        roleIds: data.roles
+          .map((roleKey) => roleIdByKey.get(roleKey.toUpperCase()))
+          .filter((value): value is number => typeof value === 'number'),
+        directPermissions: (data.directPermissions ?? []).map(normalizePermissionKey),
+        revokedPermissions: (data.revokedPermissions ?? []).map(normalizePermissionKey)
+      });
+      if (selectedUserId) {
+        queryClient.invalidateQueries({ queryKey: ['users', 'detail', selectedUserId] });
+      }
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : extractErrorMessage(error, 'Unable to update user.');
+      setFormError(message);
+      notify({ type: 'error', message });
+    }
+  });
+
+  const deleteUser = useMutation({
+    mutationFn: async (userId: number) => {
+      await api.delete(`/users/${userId}`);
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'User removed.' });
+      invalidateUsers();
+      setPanelMode('empty');
+      setSelectedUserId(null);
+      setForm(emptyForm);
+    },
+    onError: (error) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Unable to delete user.') });
+    }
+  });
+
+  const toggleStatus = useMutation({
+    mutationFn: async ({ userId, nextActive }: { userId: number; nextActive: boolean }) => {
+      setStatusUpdateId(userId);
+      const { data } = await api.patch<User>(`/users/${userId}/status`, { active: nextActive });
+      return data;
+    },
+    onSuccess: (data) => {
+      notify({
+        type: 'success',
+        message: data.active ? 'User activated.' : 'User deactivated.'
+      });
+      invalidateUsers();
+      if (panelMode === 'detail' && selectedUserId === data.id) {
+        setForm((prev) => ({ ...prev, active: data.active }));
+        queryClient.invalidateQueries({ queryKey: ['users', 'detail', data.id] });
+      }
+    },
+    onError: (error) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Unable to update status.') });
+    },
+    onSettled: () => {
+      setStatusUpdateId(null);
+    }
+  });
+
+  const handleFieldChange = <K extends keyof UserFormState>(key: K, value: UserFormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const toggleRoleSelection = (roleId: number) => {
+    setForm((prev) => {
+      const exists = prev.roleIds.includes(roleId);
+      const nextRoleIds = exists ? prev.roleIds.filter((id) => id !== roleId) : [...prev.roleIds, roleId];
+      const normalizedRolePermissions = new Set<string>();
+      roles.forEach((role) => {
+        if (nextRoleIds.includes(role.id)) {
+          role.permissions?.forEach((permission) => {
+            normalizedRolePermissions.add(normalizePermissionKey(permission));
+          });
+        }
+      });
+      const filteredDirect = prev.directPermissions
+        .map(normalizePermissionKey)
+        .filter((permissionKey) => !normalizedRolePermissions.has(permissionKey));
+      const filteredRevoked = prev.revokedPermissions
+        .map(normalizePermissionKey)
+        .filter((permissionKey) => normalizedRolePermissions.has(permissionKey));
+      return {
+        ...prev,
+        roleIds: nextRoleIds,
+        directPermissions: Array.from(new Set(filteredDirect)),
+        revokedPermissions: Array.from(new Set(filteredRevoked))
+      };
+    });
+  };
+
+  const toggleDirectPermission = (permissionKey: string, checked: boolean) => {
+    const normalized = normalizePermissionKey(permissionKey);
+    setForm((prev) => {
+      const next = new Set(prev.directPermissions.map(normalizePermissionKey));
+      const nextRevoked = new Set(prev.revokedPermissions.map(normalizePermissionKey));
+      if (rolePermissionSet.has(normalized)) {
+        return prev;
+      }
+      if (checked) {
+        next.add(normalized);
+        if (/_VIEW_GLOBAL$/i.test(normalized)) {
+          next.delete(normalized.replace(/_GLOBAL$/i, '_OWN'));
+        }
+        nextRevoked.delete(normalized);
+      } else {
+        next.delete(normalized);
+      }
+      return { ...prev, directPermissions: Array.from(next), revokedPermissions: Array.from(nextRevoked) };
+    });
+  };
+
+  const toggleRevokedPermission = (permissionKey: string, checked: boolean) => {
+    const normalized = normalizePermissionKey(permissionKey);
+    setForm((prev) => {
+      const nextRevoked = new Set(prev.revokedPermissions.map(normalizePermissionKey));
+      const nextDirect = new Set(prev.directPermissions.map(normalizePermissionKey));
+      if (checked) {
+        nextDirect.delete(normalized);
+        nextRevoked.add(normalized);
+      } else {
+        nextRevoked.delete(normalized);
+      }
+      return {
+        ...prev,
+        revokedPermissions: Array.from(nextRevoked),
+        directPermissions: Array.from(nextDirect)
+      };
+    });
+  };
+
+  const clearPanel = () => {
+    setPanelMode('empty');
+    setSelectedUserId(null);
+    setForm(emptyForm);
+    setFormError(null);
+    setActiveTab('profile');
+  };
+
+  const handleSortChange = (field: UserSortField) => {
+    setSort((prev) => {
+      if (prev.field === field) {
+        return { field, direction: prev.direction === 'asc' ? 'desc' : 'asc' };
+      }
+      return { field, direction: 'asc' };
+    });
+  };
+
+  const applyFilters = (list: User[]) =>
+    list.filter((user) => {
+      if (statusFilter === 'active' && !user.active) {
+        return false;
+      }
+      if (statusFilter === 'inactive' && user.active) {
+        return false;
+      }
+      if (audienceFilter === 'customer' && !isCustomerAccount(user)) {
+        return false;
+      }
+      if (audienceFilter === 'internal' && isCustomerAccount(user)) {
+        return false;
+      }
+      return true;
+    });
+
+  const sortUsersList = (list: User[]) => {
+    const copy = [...list];
+    const directionFactor = sort.direction === 'asc' ? 1 : -1;
+    copy.sort((a, b) => {
+      switch (sort.field) {
+        case 'email': {
+          const comparison = compareText(a.email, b.email);
+          return comparison !== 0 ? comparison * directionFactor : compareText(a.fullName, b.fullName) * directionFactor;
+        }
+        case 'status': {
+          if (a.active === b.active) {
+            return compareText(a.fullName, b.fullName) * directionFactor;
+          }
+          return ((a.active ? 1 : 0) - (b.active ? 1 : 0)) * directionFactor;
+        }
+        case 'audience': {
+          const aAudience = isCustomerAccount(a) ? 1 : 0;
+          const bAudience = isCustomerAccount(b) ? 1 : 0;
+          if (aAudience === bAudience) {
+            return compareText(a.fullName, b.fullName) * directionFactor;
+          }
+          return (aAudience - bAudience) * directionFactor;
+        }
+        case 'groups': {
+          const difference = (a.roles?.length ?? 0) - (b.roles?.length ?? 0);
+          if (difference === 0) {
+            return compareText(a.fullName, b.fullName) * directionFactor;
+          }
+          return difference * directionFactor;
+        }
+        case 'name':
+        default:
+          return compareText(a.fullName, b.fullName) * directionFactor;
+      }
+    });
+    return copy;
+  };
+
+  const users: User[] = usersQuery.data?.content ?? [];
+  const totalPages = usersQuery.data?.totalPages ?? 0;
+  const filteredUsers = useMemo(() => applyFilters(users), [users, statusFilter, audienceFilter]);
+  const sortedUsers = useMemo(() => sortUsersList(filteredUsers), [filteredUsers, sort]);
+
+  const fetchAllUsers = async (): Promise<User[]> => {
+    const serverSortable: UserSortField[] = ['name', 'email', 'status'];
+    const serverSortField = serverSortable.includes(sort.field) ? sort.field : 'name';
+    const direction = serverSortField === sort.field ? sort.direction : 'asc';
+    const size = 250;
+    const baseParams: Record<string, unknown> = {
+      size,
+      sort: serverSortField,
+      direction
+    };
+    if (searchTerm.trim()) {
+      baseParams.search = searchTerm.trim();
+    }
+
+    const aggregated: User[] = [];
+    let pageIndex = 0;
+    let totalPagesCount = 1;
+
+    do {
+      const params = { ...baseParams, page: pageIndex };
+      const { data } = await api.get<Pagination<User>>('/users', { params });
+      aggregated.push(...(data.content ?? []));
+      totalPagesCount = data.totalPages ?? 1;
+      pageIndex += 1;
+      if (pageIndex >= totalPagesCount) {
+        break;
+      }
+    } while (pageIndex < totalPagesCount && pageIndex < 50);
+
+    return aggregated;
+  };
+
+  const handleExportUsers = async (format: ExportFormat) => {
+    if (!canExportUsers || isExporting) {
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const allUsers = await fetchAllUsers();
+      const filtered = applyFilters(allUsers);
+      const sorted = sortUsersList(filtered);
+      if (!sorted.length) {
+        notify({ type: 'error', message: 'There are no users to export for the current filters.' });
+        return;
+      }
+      const columns = [
+        { key: 'name', header: 'Name' },
+        { key: 'email', header: 'Email' },
+        { key: 'status', header: 'Status' },
+        { key: 'groups', header: 'Groups' },
+        { key: 'audience', header: 'Audience' }
+      ];
+      const rows = sorted.map((user) => ({
+        name: user.fullName,
+        email: user.email,
+        status: user.active ? 'Active' : 'Inactive',
+        groups: user.roles.length ? user.roles.join(', ') : '—',
+        audience: isCustomerAccount(user) ? 'Customer' : 'Internal'
+      }));
+      exportDataset({
+        format,
+        columns,
+        rows,
+        fileName: 'users-and-customers',
+        title: 'Users & customers'
+      });
+    } catch (error) {
+      notify({ type: 'error', message: 'Unable to export users. Please try again.' });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const metrics = summaryQuery.data;
+  const directPermissionSet = useMemo(() => {
+    const next = new Set(form.directPermissions.map(normalizePermissionKey));
+    return next;
+  }, [form.directPermissions]);
+
+  const revokedPermissionSet = useMemo(() => {
+    const next = new Set(form.revokedPermissions.map(normalizePermissionKey));
+    return next;
+  }, [form.revokedPermissions]);
+
+  const rolePermissionSet = useMemo(() => {
+    const assignedRoles = new Set(form.roleIds);
+    const collected = new Set<string>();
+    roles.forEach((role) => {
+      if (assignedRoles.has(role.id)) {
+        role.permissions?.forEach((permission) => {
+          collected.add(normalizePermissionKey(permission));
+        });
+      }
+    });
+    return collected;
+  }, [form.roleIds, roles]);
+
+  const effectivePermissionKeys = useMemo(() => {
+    const combined = new Set<string>();
+    rolePermissionSet.forEach((key) => {
+      if (!revokedPermissionSet.has(key)) {
+        combined.add(key);
+      }
+    });
+    directPermissionSet.forEach((key) => {
+      if (!revokedPermissionSet.has(key)) {
+        combined.add(key);
+      }
+    });
+    return Array.from(combined).sort();
+  }, [rolePermissionSet, directPermissionSet, revokedPermissionSet]);
+
+  const revokedPermissionKeys = useMemo(() => {
+    return Array.from(revokedPermissionSet).sort();
+  }, [revokedPermissionSet]);
+
+  const renderSummaryCards = () => (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Total users</p>
+        <p className="mt-2 text-3xl font-semibold text-slate-800">{metrics?.totalUsers ?? 0}</p>
+        <p className="mt-1 text-xs text-slate-500">Across internal teams and customer accounts.</p>
+      </div>
+      <div className="rounded-2xl border border-emerald-100 bg-emerald-50/60 p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Active</p>
+        <p className="mt-2 text-3xl font-semibold text-emerald-700">{metrics?.activeUsers ?? 0}</p>
+        <p className="mt-1 text-xs text-emerald-600">Users currently able to sign in.</p>
+      </div>
+      <div className="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600">Internal team</p>
+        <p className="mt-2 text-3xl font-semibold text-indigo-700">{metrics?.internalUsers ?? 0}</p>
+        <p className="mt-1 text-xs text-indigo-600">Members without the customer role.</p>
+      </div>
+      <div className="rounded-2xl border border-blue-100 bg-blue-50/60 p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">Customer accounts</p>
+        <p className="mt-2 text-3xl font-semibold text-blue-700">{metrics?.customerUsers ?? 0}</p>
+        <p className="mt-1 text-xs text-blue-600">Users holding the customer role.</p>
+      </div>
+    </div>
+  );
+
+  const renderFilters = () => (
+    <div className="flex flex-col gap-4 border-b border-slate-200 px-6 py-4 lg:flex-row lg:items-end">
+      <div className="flex-1">
+        <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Search</label>
+        <input
+          type="search"
+          value={searchDraft}
+          onChange={(event) => setSearchDraft(event.target.value)}
+          placeholder="Search by name or email"
+          className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+        />
+      </div>
+      <div className="grid w-full gap-4 sm:grid-cols-2 lg:w-auto lg:flex lg:items-end lg:gap-4">
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Status</label>
+          <select
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value as typeof statusFilter)}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          >
+            <option value="all">All</option>
+            <option value="active">Active</option>
+            <option value="inactive">Inactive</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Audience</label>
+          <select
+            value={audienceFilter}
+            onChange={(event) => setAudienceFilter(event.target.value as typeof audienceFilter)}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          >
+            <option value="all">All users</option>
+            <option value="internal">Internal</option>
+            <option value="customer">Customers</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Rows</label>
+          <select
+            value={pageSize}
+            onChange={(event) => setPageSize(Number(event.target.value))}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          >
+            {PAGE_SIZE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderTable = () => (
+    <div className="flex flex-col">
+      {renderFilters()}
+      <div className="flex-1 overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-200">
+          <thead className="bg-slate-50">
+            <tr>
+              <SortableColumnHeader
+                label="Name"
+                field="name"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <SortableColumnHeader
+                label="Email"
+                field="email"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <SortableColumnHeader
+                label="Status"
+                field="status"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <SortableColumnHeader
+                label="Groups"
+                field="groups"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <SortableColumnHeader
+                label="Audience"
+                field="audience"
+                currentField={sort.field}
+                direction={sort.direction}
+                onSort={handleSortChange}
+              />
+              <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 bg-white">
+            {usersQuery.isLoading ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-sm text-slate-500">
+                  Loading users…
+                </td>
+              </tr>
+            ) : sortedUsers.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-6 text-center text-sm text-slate-500">
+                  No users match the current filters.
+                </td>
+              </tr>
+            ) : (
+              sortedUsers.map((user) => {
+                const isSelected = panelMode === 'detail' && selectedUserId === user.id;
+                const isSelfSuperAdmin = isSuperAdmin && currentUserId === user.id;
+                const disableStatusToggle =
+                  isSelfSuperAdmin || (toggleStatus.isPending && statusUpdateId === user.id);
+                return (
+                  <tr
+                    key={user.id}
+                    className={`cursor-pointer transition hover:bg-blue-50/40 ${
+                      isSelected ? 'bg-blue-50/60' : ''
+                    }`}
+                    onClick={() => {
+                      setSelectedUserId(user.id);
+                      setPanelMode('detail');
+                    }}
+                  >
+                    <td className="px-4 py-3 text-sm font-medium text-slate-800">
+                      <div>{user.fullName}</div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-slate-600">{user.email}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3 text-xs font-semibold">
+                        <span className={user.active ? 'text-emerald-600' : 'text-slate-500'}>
+                          {user.active ? 'Active' : 'Inactive'}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            if (isSelfSuperAdmin) {
+                              return;
+                            }
+                            toggleStatus.mutate({ userId: user.id, nextActive: !user.active });
+                          }}
+                          disabled={disableStatusToggle}
+                          className={`relative inline-flex h-6 w-11 items-center rounded-full border transition-all focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 ${
+                            user.active ? 'border-emerald-200 bg-emerald-500/90' : 'border-slate-300 bg-slate-200'
+                          }`}
+                          aria-label={user.active ? `Deactivate ${user.fullName}` : `Activate ${user.fullName}`}
+                          title={
+                            isSelfSuperAdmin
+                              ? 'Super Admins cannot change their own status.'
+                              : user.active
+                              ? `Deactivate ${user.fullName}`
+                              : `Activate ${user.fullName}`
+                          }
+                        >
+                          <span
+                            className={`absolute left-1 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                              user.active ? 'translate-x-5' : 'translate-x-0'
+                            }`}
+                          />
+                        </button>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-2 text-xs text-slate-600">
+                        {user.roles.map((role) => (
+                          <span key={role} className="rounded-full bg-slate-100 px-2 py-1 font-semibold uppercase tracking-wide">
+                            {role}
+                          </span>
+                        ))}
+                        {user.roles.length === 0 && <span className="text-slate-400">No roles</span>}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-slate-600">
+                      {isCustomerAccount(user) ? 'Customer' : 'Internal'}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            if (isSelfSuperAdmin) {
+                              return;
+                            }
+                            setSelectedUserId(user.id);
+                            setPanelMode('detail');
+                          }}
+                          className="rounded-full border border-slate-200 p-2 text-slate-500 transition hover:border-slate-300 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                          aria-label={`Edit ${user.fullName}`}
+                          disabled={isSelfSuperAdmin}
+                          title={isSelfSuperAdmin ? 'Super Admins cannot edit their own record from this list.' : `Edit ${user.fullName}`}
+                        >
+                          <PencilIcon />
+                        </button>
+                        {canDeleteUsers && (
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              if (isSelfSuperAdmin) {
+                                return;
+                              }
+                              if (typeof window !== 'undefined') {
+                                const confirmed = window.confirm(`Delete ${user.fullName}?`);
+                                if (!confirmed) {
+                                  return;
+                                }
+                              }
+                              deleteUser.mutate(user.id);
+                            }}
+                            className="rounded-full border border-rose-200 p-2 text-rose-500 transition hover:border-rose-300 hover:text-rose-600 disabled:cursor-not-allowed disabled:opacity-50"
+                            aria-label={`Delete ${user.fullName}`}
+                            disabled={deleteUser.isPending || isSelfSuperAdmin}
+                            title={
+                              isSelfSuperAdmin
+                                ? 'Super Admins cannot delete their own account from this list.'
+                                : `Delete ${user.fullName}`
+                            }
+                          >
+                            <TrashIcon />
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex items-center justify-between border-t border-slate-200 px-6 py-3 text-sm text-slate-500">
+        <span>
+          Page {totalPages === 0 ? 0 : page + 1} of {Math.max(totalPages, 1)}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+            disabled={page === 0 || usersQuery.isLoading}
+            className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.min(prev + 1, Math.max(totalPages - 1, 0)))}
+            disabled={page >= totalPages - 1 || usersQuery.isLoading}
+            className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderProfileTab = (isEditable: boolean, isCreate: boolean) => (
+    <div className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Full name</label>
+          <input
+            type="text"
+            value={form.fullName}
+            onChange={(event) => handleFieldChange('fullName', event.target.value)}
+            required
+            minLength={2}
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Email</label>
+          <input
+            type="email"
+            value={form.email}
+            onChange={(event) => handleFieldChange('email', event.target.value)}
+            required
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Password</label>
+          <input
+            type="password"
+            value={form.password}
+            onChange={(event) => handleFieldChange('password', event.target.value)}
+            required={isCreate}
+            minLength={isCreate ? 8 : 0}
+            placeholder={isCreate ? 'At least 8 characters' : 'Leave blank to keep the current password'}
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+          <p className="mt-1 text-xs text-slate-500">Passwords must contain at least 8 characters.</p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Status</label>
+          <select
+            value={form.active ? 'true' : 'false'}
+            onChange={(event) => handleFieldChange('active', event.target.value === 'true')}
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          >
+            <option value="true">Active</option>
+            <option value="false">Inactive</option>
+          </select>
+        </div>
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
+        Customer accounts are represented as users holding the <span className="font-semibold">CUSTOMER</span> role. Assign or
+        revoke that role here to control access.
+      </div>
+    </div>
+  );
+
+  const renderAccessTab = (isEditable: boolean) => (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-slate-800">User Management</h1>
-      {canCreate && (
-        <form onSubmit={handleSubmit} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <div className="grid gap-4 sm:grid-cols-3">
-            <div>
-              <label className="block text-sm font-medium text-slate-600">Full name</label>
-              <input
-                type="text"
-                required
-                value={form.fullName}
-                onChange={(e) => setForm((prev) => ({ ...prev, fullName: e.target.value }))}
-                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-slate-600">Email</label>
-              <input
-                type="email"
-                required
-                value={form.email}
-                onChange={(e) => setForm((prev) => ({ ...prev, email: e.target.value }))}
-                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-slate-600">Password</label>
-              <input
-                type="password"
-                required
-                value={form.password}
-                onChange={(e) => setForm((prev) => ({ ...prev, password: e.target.value }))}
-                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-              />
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h3 className="text-sm font-semibold text-slate-800">Roles</h3>
+        <p className="mt-1 text-xs text-slate-500">
+          Roles supply the baseline permissions for each user. Grant the customer role to expose customer-only experiences.
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          {roles.map((role) => {
+            const checked = form.roleIds.includes(role.id);
+            return (
+              <label
+                key={role.id}
+                className={`flex cursor-pointer items-center justify-between rounded-lg border px-3 py-2 text-sm transition ${
+                  checked ? 'border-primary bg-primary/5 text-primary' : 'border-slate-200 text-slate-600'
+                } ${isEditable ? 'hover:border-primary/60' : 'opacity-70'}`}
+              >
+                <span>
+                  <span className="font-semibold text-slate-800">{role.name}</span>
+                  <span className="ml-2 text-[11px] uppercase tracking-wider text-slate-400">{role.key}</span>
+                </span>
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={checked}
+                  onChange={() => toggleRoleSelection(role.id)}
+                  disabled={!isEditable}
+                />
+              </label>
+            );
+          })}
+        </div>
+      </section>
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h3 className="text-sm font-semibold text-slate-800">Direct permission overrides</h3>
+        <p className="mt-1 text-xs text-slate-500">
+          Apply additional permissions to this user without altering the underlying role. Selecting “View (Global)” will
+          automatically disable “View (Own)” for the same feature.
+        </p>
+        <div className="mt-4 space-y-4">
+          {permissionGroups.map((group) => {
+            const slotEntries = Object.entries(group.slots);
+            const extras = group.extras;
+            return (
+              <div key={group.feature} className="rounded-lg border border-slate-200">
+                <div className="border-b border-slate-200 bg-slate-50 px-4 py-3">
+                  <h4 className="text-sm font-semibold text-slate-800">{group.feature}</h4>
+                </div>
+                <div className="grid gap-3 p-4 sm:grid-cols-2">
+                  {slotEntries.map(([slot, option]) => {
+                    if (!option) {
+                      return null;
+                    }
+                    const normalized = normalizePermissionKey(option.key);
+                    const checked = directPermissionSet.has(normalized);
+                    const disableOwn = /_VIEW_OWN$/i.test(normalized) &&
+                      directPermissionSet.has(normalized.replace(/_OWN$/i, '_GLOBAL'));
+                    const inherited = rolePermissionSet.has(normalized);
+                    const isRevoked = revokedPermissionSet.has(normalized);
+                    const isDisabled = !isEditable || disableOwn || inherited;
+                    const borderClasses = isRevoked
+                      ? 'border-rose-300 bg-rose-50 text-rose-600'
+                      : checked
+                      ? 'border-primary bg-primary/5 text-primary'
+                      : inherited
+                      ? 'border-slate-200 bg-slate-50 text-slate-500'
+                      : 'border-slate-200 text-slate-600';
+                    return (
+                      <label
+                        key={option.id}
+                        className={`flex items-start gap-3 rounded-lg border px-3 py-2 text-sm transition ${borderClasses} ${
+                          isEditable && !inherited ? 'hover:border-primary/60' : 'opacity-80'
+                        }`}
+                        >
+                        <input
+                          type="checkbox"
+                          className="mt-1 h-4 w-4"
+                          checked={checked}
+                          disabled={isDisabled}
+                          onChange={(event) => toggleDirectPermission(option.key, event.target.checked)}
+                          title={
+                            inherited
+                              ? 'Granted through assigned roles'
+                              : disableOwn
+                              ? 'View (Global) already selected for this feature.'
+                              : undefined
+                          }
+                        />
+                        <span>
+                          <span className="block font-semibold text-slate-800">{SLOT_LABELS[slot] ?? option.label}</span>
+                          <span className="text-xs uppercase tracking-wide text-slate-400">{option.key}</span>
+                          {inherited && (
+                            <span className="mt-1 inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+                              Inherited from role
+                            </span>
+                          )}
+                          {isRevoked && (
+                            <span className="mt-1 inline-flex items-center rounded-full bg-rose-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-rose-600">
+                              Revoked for this user
+                            </span>
+                          )}
+                          {inherited && (
+                            <label className="mt-2 inline-flex items-center gap-2 text-xs font-medium text-rose-600">
+                              <input
+                                type="checkbox"
+                                className="h-3.5 w-3.5"
+                                checked={isRevoked}
+                                onChange={(event) => toggleRevokedPermission(option.key, event.target.checked)}
+                                disabled={!isEditable}
+                              />
+                              Revoke for this user
+                            </label>
+                          )}
+                        </span>
+                      </label>
+                    );
+                  })}
+                  {extras.map((option) => {
+                    const normalized = normalizePermissionKey(option.key);
+                    const checked = directPermissionSet.has(normalized);
+                    const inherited = rolePermissionSet.has(normalized);
+                    const isRevoked = revokedPermissionSet.has(normalized);
+                    return (
+                      <label
+                        key={option.id}
+                        className={`flex items-start gap-3 rounded-lg border px-3 py-2 text-sm transition ${
+                          isRevoked
+                            ? 'border-rose-300 bg-rose-50 text-rose-600'
+                            : checked
+                            ? 'border-primary bg-primary/5 text-primary'
+                            : inherited
+                            ? 'border-slate-200 bg-slate-50 text-slate-500'
+                            : 'border-slate-200 text-slate-600'
+                        } ${isEditable && !inherited ? 'hover:border-primary/60' : 'opacity-80'}`}
+                      >
+                        <input
+                          type="checkbox"
+                          className="mt-1 h-4 w-4"
+                          checked={checked}
+                          disabled={!isEditable || inherited}
+                          onChange={(event) => toggleDirectPermission(option.key, event.target.checked)}
+                          title={inherited ? 'Granted through assigned roles' : undefined}
+                        />
+                        <span>
+                          <span className="block font-semibold text-slate-800">{option.label}</span>
+                          <span className="text-xs uppercase tracking-wide text-slate-400">{option.key}</span>
+                          {inherited && (
+                            <span className="mt-1 inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+                              Inherited from role
+                            </span>
+                          )}
+                          {isRevoked && (
+                            <span className="mt-1 inline-flex items-center rounded-full bg-rose-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-rose-600">
+                              Revoked for this user
+                            </span>
+                          )}
+                          {inherited && (
+                            <label className="mt-2 inline-flex items-center gap-2 text-xs font-medium text-rose-600">
+                              <input
+                                type="checkbox"
+                                className="h-3.5 w-3.5"
+                                checked={isRevoked}
+                                onChange={(event) => toggleRevokedPermission(option.key, event.target.checked)}
+                                disabled={!isEditable}
+                              />
+                              Revoke for this user
+                            </label>
+                          )}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+      <section className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+        <h4 className="text-sm font-semibold text-slate-700">Effective permissions</h4>
+        <p className="mt-1 text-xs text-slate-500">
+          Includes role-derived permissions plus any direct overrides applied above.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {effectivePermissionKeys.length === 0 ? (
+            <span className="text-xs text-slate-400">No permissions selected yet.</span>
+          ) : (
+            effectivePermissionKeys.map((permissionKey) => {
+              const permission = permissionLookup.get(permissionKey);
+              const isDirect = directPermissionSet.has(permissionKey);
+              const badgeClasses = isDirect
+                ? 'bg-emerald-100 text-emerald-700'
+                : 'bg-blue-100 text-blue-700';
+              return (
+                <span
+                  key={permissionKey}
+                  className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${badgeClasses}`}
+                >
+                  {permission?.name ?? permissionKey}
+                </span>
+              );
+            })
+          )}
+        </div>
+        {revokedPermissionKeys.length > 0 && (
+          <div className="mt-4">
+            <h5 className="text-xs font-semibold uppercase tracking-wide text-rose-500">Revoked for this user</h5>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {revokedPermissionKeys.map((permissionKey) => {
+                const permission = permissionLookup.get(permissionKey);
+                return (
+                  <span
+                    key={`revoked-${permissionKey}`}
+                    className="rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-600"
+                  >
+                    {permission?.name ?? permissionKey}
+                  </span>
+                );
+              })}
             </div>
           </div>
-          <button
-            type="submit"
-            className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-            disabled={createUser.isLoading}
-          >
-            {createUser.isLoading ? 'Creating...' : 'Create user'}
-          </button>
-        </form>
-      )}
+        )}
+        <div className="mt-3 flex flex-wrap gap-4 text-[11px] uppercase tracking-wide text-slate-400">
+          <span className="inline-flex items-center gap-2">
+            <span className="h-2.5 w-2.5 rounded-full bg-blue-500" /> Role permissions
+          </span>
+          <span className="inline-flex items-center gap-2">
+            <span className="h-2.5 w-2.5 rounded-full bg-emerald-500" /> Direct overrides
+          </span>
+          <span className="inline-flex items-center gap-2">
+            <span className="h-2.5 w-2.5 rounded-full bg-rose-500" /> Revoked overrides
+          </span>
+        </div>
+      </section>
+    </div>
+  );
 
-      <DataTable title="Team members">
-        <thead>
-          <tr>
-            <th className="px-3 py-2 text-left">Name</th>
-            <th className="px-3 py-2 text-left">Email</th>
-            <th className="px-3 py-2 text-left">Roles</th>
-            {canDelete && <th className="px-3 py-2 text-right">Actions</th>}
-          </tr>
-        </thead>
-        <tbody>
-          {data?.map((user) => (
-            <tr key={user.id} className="border-t border-slate-200">
-              <td className="px-3 py-2">{user.fullName}</td>
-              <td className="px-3 py-2">{user.email}</td>
-              <td className="px-3 py-2">{user.roles.join(', ') || '—'}</td>
-              {canDelete && (
-                <td className="px-3 py-2 text-right">
-                  <button
-                    onClick={() => deleteUser.mutate(user.id)}
-                    className="text-sm text-red-600 hover:underline"
-                  >
-                    Remove
-                  </button>
-                </td>
-              )}
-            </tr>
-          ))}
-        </tbody>
-      </DataTable>
+  const renderPanel = () => {
+    const isCreate = panelMode === 'create';
+    const isEditable = isCreate ? canCreateUser : canManageUsers;
+    const isSaving = isCreate ? createUser.isPending : updateUser.isPending;
+    const isLoadingDetail = panelMode === 'detail' && selectedUserQuery.isLoading;
+
+    const headerTitle = isCreate
+      ? 'Create user or customer'
+      : selectedUserQuery.data?.fullName ?? 'Loading user…';
+    const headerSubtitle = isCreate
+      ? 'Provision access for an internal teammate or customer contact.'
+      : selectedUserQuery.data?.email ?? '';
+
+    return (
+      <form
+        className="flex flex-col gap-6 rounded-2xl border border-slate-200 bg-white shadow-sm"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!isEditable) {
+            return;
+          }
+          setFormError(null);
+          if (isCreate) {
+            createUser.mutate();
+          } else {
+            updateUser.mutate();
+          }
+        }}
+      >
+        <header className="flex flex-col gap-4 border-b border-slate-200 bg-slate-50 px-6 py-5 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-start gap-4">
+            <button
+              type="button"
+              onClick={clearPanel}
+              className="rounded-full border border-slate-200 bg-white p-2 text-slate-600 transition hover:border-primary/40 hover:text-primary"
+              aria-label="Back to user directory"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} className="h-5 w-5">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m15 19-7-7 7-7" />
+              </svg>
+            </button>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-primary">{isCreate ? 'New profile' : `#${selectedUserId ?? ''} Profile`}</p>
+              <h2 className="mt-1 text-2xl font-semibold text-slate-900">{headerTitle}</h2>
+              {headerSubtitle && <p className="text-sm text-slate-500">{headerSubtitle}</p>}
+            </div>
+          </div>
+          {!isCreate && selectedUserQuery.data && (
+            <div className="flex flex-wrap gap-3 text-xs text-slate-500">
+              <span className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 font-semibold uppercase tracking-wide text-slate-600">
+                <span className={`h-2 w-2 rounded-full ${selectedUserQuery.data.active ? 'bg-emerald-500' : 'bg-slate-400'}`} />
+                {selectedUserQuery.data.active ? 'Active' : 'Inactive'}
+              </span>
+              {selectedUserQuery.data.roles.map((role) => (
+                <span key={role} className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 font-semibold uppercase tracking-wide text-slate-600">
+                  {role}
+                </span>
+              ))}
+            </div>
+          )}
+        </header>
+        <div className="grid gap-0 border-b border-slate-200 lg:grid-cols-[240px,1fr]">
+          <nav className="flex shrink-0 flex-row gap-2 border-b border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-600 lg:flex-col lg:border-b-0 lg:border-r">
+            {(
+              [
+                { key: 'profile', label: 'Profile details' },
+                { key: 'access', label: 'Roles & permissions' }
+              ] as Array<{ key: DetailTab; label: string }>
+            ).map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setActiveTab(tab.key)}
+                className={`rounded-lg px-3 py-2 text-left transition ${
+                  activeTab === tab.key
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-slate-600 hover:bg-slate-100'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </nav>
+          <div className="flex-1 px-6 py-6">
+            {isLoadingDetail ? (
+              <p className="text-sm text-slate-500">Loading user details…</p>
+            ) : activeTab === 'profile' ? (
+              renderProfileTab(isEditable, isCreate)
+            ) : (
+              renderAccessTab(isEditable)
+            )}
+          </div>
+        </div>
+        <footer className="flex flex-col gap-3 bg-slate-50 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+          {formError ? (
+            <p className="text-sm text-rose-600">{formError}</p>
+          ) : (
+            <span className="text-xs text-slate-500">
+              Changes apply immediately after saving and will not modify the underlying role definitions.
+            </span>
+          )}
+          <div className="flex flex-wrap items-center gap-3">
+            {panelMode === 'detail' && canDeleteUsers && selectedUserId && (
+              <button
+                type="button"
+                onClick={() => deleteUser.mutate(selectedUserId)}
+                disabled={deleteUser.isPending}
+                className="rounded-lg border border-rose-200 px-4 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {deleteUser.isPending ? 'Removing…' : 'Remove user'}
+              </button>
+            )}
+            {panelMode === 'detail' && selectedUserQuery.data && isEditable && (
+              <button
+                type="button"
+                onClick={() => {
+                  const detail = selectedUserQuery.data;
+                  setForm({
+                    fullName: detail.fullName,
+                    email: detail.email,
+                    password: '',
+                    active: detail.active,
+                    roleIds: detail.roles
+                      .map((roleKey) => roleIdByKey.get(roleKey.toUpperCase()))
+                      .filter((value): value is number => typeof value === 'number'),
+                    directPermissions: (detail.directPermissions ?? []).map(normalizePermissionKey),
+                    revokedPermissions: (detail.revokedPermissions ?? []).map(normalizePermissionKey)
+                  });
+                  setFormError(null);
+                }}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+              >
+                Reset changes
+              </button>
+            )}
+            <button
+              type="submit"
+              disabled={!isEditable || isSaving}
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isCreate ? (isSaving ? 'Creating…' : 'Create user') : isSaving ? 'Saving…' : 'Save changes'}
+            </button>
+          </div>
+        </footer>
+      </form>
+    );
+  };
+
+  const isDirectoryView = panelMode === 'empty';
+
+  return (
+    <div className="flex min-h-full flex-col gap-6 px-6 py-6">
+      <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">Users &amp; customers</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            Manage internal teammates and customer contacts from a single, permission-aware workspace.
+          </p>
+        </div>
+        {isDirectoryView && (
+          <div className="flex flex-wrap items-center gap-3">
+            {canExportUsers && (
+              <ExportMenu onSelect={handleExportUsers} disabled={usersQuery.isLoading} isBusy={isExporting} />
+            )}
+            {canCreateUser && (
+              <button
+                type="button"
+                onClick={() => setPanelMode('create')}
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-600"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.6}
+                  className="h-4 w-4"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m6-6H6" />
+                </svg>
+                New user
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      {isDirectoryView ? (
+        <>
+          {renderSummaryCards()}
+          <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">{renderTable()}</div>
+        </>
+      ) : (
+        renderPanel()
+      )}
     </div>
   );
 };

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,24 +1,4 @@
-export type PermissionKey =
-  | 'USER_VIEW'
-  | 'USER_CREATE'
-  | 'USER_UPDATE'
-  | 'USER_DELETE'
-  | 'ROLE_VIEW'
-  | 'ROLE_CREATE'
-  | 'ROLE_UPDATE'
-  | 'ROLE_DELETE'
-  | 'PERMISSION_VIEW'
-  | 'PERMISSION_CREATE'
-  | 'PERMISSION_UPDATE'
-  | 'PERMISSION_DELETE'
-  | 'CUSTOMER_VIEW'
-  | 'CUSTOMER_CREATE'
-  | 'CUSTOMER_UPDATE'
-  | 'CUSTOMER_DELETE'
-  | 'INVOICE_VIEW'
-  | 'INVOICE_CREATE'
-  | 'INVOICE_UPDATE'
-  | 'INVOICE_DELETE';
+export type PermissionKey = string;
 
 export interface RoleSummary {
   id: number;
@@ -34,6 +14,8 @@ export interface UserSummary {
   active: boolean;
   roles: string[];
   permissions: PermissionKey[];
+  directPermissions: PermissionKey[];
+  revokedPermissions: PermissionKey[];
 }
 
 export interface AuthResponse {
@@ -42,4 +24,6 @@ export interface AuthResponse {
   user: UserSummary;
   roles: string[];
   permissions: PermissionKey[];
+  directPermissions: PermissionKey[];
+  revokedPermissions: PermissionKey[];
 }

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -15,6 +15,16 @@ export interface User extends Record<string, unknown> {
   active: boolean;
   roles: string[];
   permissions: PermissionKey[];
+  directPermissions: PermissionKey[];
+  revokedPermissions: PermissionKey[];
+}
+
+export interface UserSummaryMetrics {
+  totalUsers: number;
+  activeUsers: number;
+  inactiveUsers: number;
+  customerUsers: number;
+  internalUsers: number;
 }
 
 export interface Role {

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+export const extractErrorMessage = (error: unknown, fallback: string) => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data;
+    if (data && typeof data === 'object') {
+      const message = (data as { message?: string; error?: string }).message;
+      if (message) return message;
+      const errorText = (data as { error?: string }).error;
+      if (errorText) return errorText;
+    }
+    if (typeof error.message === 'string' && error.message) {
+      return error.message;
+    }
+  }
+  return fallback;
+};

--- a/frontend/src/utils/exporters.ts
+++ b/frontend/src/utils/exporters.ts
@@ -1,0 +1,476 @@
+export type ExportFormat = 'xlsx' | 'csv' | 'pdf' | 'print';
+
+export interface ExportColumn {
+  key: string;
+  header: string;
+}
+
+export type ExportRow = Record<string, string | number | boolean | null | undefined>;
+
+const textEncoder = new TextEncoder();
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+const escapePdfText = (value: string) => value.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+
+const padEnd = (value: string, length: number) => {
+  if (value.length >= length) {
+    return value;
+  }
+  return value + ' '.repeat(length - value.length);
+};
+
+const toArrayBuffer = (data: Uint8Array): ArrayBuffer =>
+  data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+
+const toColumnLetter = (index: number) => {
+  let dividend = index;
+  let columnLabel = '';
+  while (dividend > 0) {
+    let modulo = (dividend - 1) % 26;
+    columnLabel = String.fromCharCode(65 + modulo) + columnLabel;
+    dividend = Math.floor((dividend - modulo) / 26);
+  }
+  return columnLabel || 'A';
+};
+
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i += 1) {
+    let c = i;
+    for (let k = 0; k < 8; k += 1) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+const crc32 = (data: Uint8Array) => {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i += 1) {
+    const byte = data[i];
+    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+const toDosTime = (date: Date) => {
+  const seconds = Math.floor(date.getSeconds() / 2);
+  return (date.getHours() << 11) | (date.getMinutes() << 5) | seconds;
+};
+
+const toDosDate = (date: Date) => {
+  const year = date.getFullYear();
+  const safeYear = Math.max(1980, Math.min(2107, year));
+  return ((safeYear - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate();
+};
+
+type ZipEntry = {
+  path: string;
+  data: Uint8Array;
+  date?: Date;
+};
+
+const createZip = (entries: ZipEntry[]): Uint8Array => {
+  let offset = 0;
+  const localParts: Uint8Array[] = [];
+  const centralParts: Uint8Array[] = [];
+  const now = new Date();
+
+  entries.forEach((entry) => {
+    const filenameBytes = textEncoder.encode(entry.path);
+    const data = entry.data;
+    const crc = crc32(data);
+    const size = data.length;
+    const date = entry.date ?? now;
+    const modTime = toDosTime(date);
+    const modDate = toDosDate(date);
+    const localHeaderLength = 30 + filenameBytes.length;
+    const local = new Uint8Array(localHeaderLength + size);
+    const localView = new DataView(local.buffer);
+
+    let pointer = 0;
+    localView.setUint32(pointer, 0x04034b50, true);
+    pointer += 4;
+    localView.setUint16(pointer, 20, true);
+    pointer += 2;
+    localView.setUint16(pointer, 0, true);
+    pointer += 2;
+    localView.setUint16(pointer, 0, true);
+    pointer += 2;
+    localView.setUint16(pointer, modTime, true);
+    pointer += 2;
+    localView.setUint16(pointer, modDate, true);
+    pointer += 2;
+    localView.setUint32(pointer, crc, true);
+    pointer += 4;
+    localView.setUint32(pointer, size, true);
+    pointer += 4;
+    localView.setUint32(pointer, size, true);
+    pointer += 4;
+    localView.setUint16(pointer, filenameBytes.length, true);
+    pointer += 2;
+    localView.setUint16(pointer, 0, true);
+    pointer += 2;
+
+    local.set(filenameBytes, pointer);
+    pointer += filenameBytes.length;
+    local.set(data, pointer);
+
+    localParts.push(local);
+
+    const centralHeaderLength = 46 + filenameBytes.length;
+    const central = new Uint8Array(centralHeaderLength);
+    const centralView = new DataView(central.buffer);
+    pointer = 0;
+    centralView.setUint32(pointer, 0x02014b50, true);
+    pointer += 4;
+    centralView.setUint16(pointer, 20, true);
+    pointer += 2;
+    centralView.setUint16(pointer, 20, true);
+    pointer += 2;
+    centralView.setUint16(pointer, 0, true);
+    pointer += 2;
+    centralView.setUint16(pointer, 0, true);
+    pointer += 2;
+    centralView.setUint16(pointer, modTime, true);
+    pointer += 2;
+    centralView.setUint16(pointer, modDate, true);
+    pointer += 2;
+    centralView.setUint32(pointer, crc, true);
+    pointer += 4;
+    centralView.setUint32(pointer, size, true);
+    pointer += 4;
+    centralView.setUint32(pointer, size, true);
+    pointer += 4;
+    centralView.setUint16(pointer, filenameBytes.length, true);
+    pointer += 2;
+    centralView.setUint16(pointer, 0, true);
+    pointer += 2;
+    centralView.setUint16(pointer, 0, true);
+    pointer += 2;
+    centralView.setUint16(pointer, 0, true);
+    pointer += 2;
+    centralView.setUint16(pointer, 0, true);
+    pointer += 2;
+    centralView.setUint32(pointer, 0, true);
+    pointer += 4;
+    centralView.setUint32(pointer, offset, true);
+    pointer += 4;
+    central.set(filenameBytes, pointer);
+
+    centralParts.push(central);
+    offset += local.length;
+  });
+
+  const centralSize = centralParts.reduce((total, part) => total + part.length, 0);
+  const centralOffset = offset;
+  const end = new Uint8Array(22);
+  const endView = new DataView(end.buffer);
+  endView.setUint32(0, 0x06054b50, true);
+  endView.setUint16(4, 0, true);
+  endView.setUint16(6, 0, true);
+  endView.setUint16(8, entries.length, true);
+  endView.setUint16(10, entries.length, true);
+  endView.setUint32(12, centralSize, true);
+  endView.setUint32(16, centralOffset, true);
+  endView.setUint16(20, 0, true);
+
+  const totalSize = offset + centralSize + end.length;
+  const result = new Uint8Array(totalSize);
+  let position = 0;
+  localParts.forEach((part) => {
+    result.set(part, position);
+    position += part.length;
+  });
+  centralParts.forEach((part) => {
+    result.set(part, position);
+    position += part.length;
+  });
+  result.set(end, position);
+
+  return result;
+};
+
+const buildSheetXml = (columns: ExportColumn[], rows: string[][]): string => {
+  const headerCells = columns
+    .map((column, index) => `<c r="${toColumnLetter(index + 1)}1" t="inlineStr"><is><t>${escapeXml(column.header)}</t></is></c>`)
+    .join('');
+
+  const bodyRows = rows
+    .map((row, rowIndex) => {
+      const cells = row
+        .map((value, columnIndex) => {
+          const cellValue = escapeXml(value);
+          return `<c r="${toColumnLetter(columnIndex + 1)}${rowIndex + 2}" t="inlineStr"><is><t>${cellValue}</t></is></c>`;
+        })
+        .join('');
+      return `<row r="${rowIndex + 2}">${cells}</row>`;
+    })
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">` +
+    `<sheetData><row r="1">${headerCells}</row>${bodyRows}</sheetData></worksheet>`;
+};
+
+const buildWorkbookXml = (sheetName: string) =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+  `<sheets><sheet name="${escapeXml(sheetName)}" sheetId="1" r:id="rId1"/></sheets></workbook>`;
+
+const buildContentTypesXml = () =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Default Extension="xml" ContentType="application/xml"/>' +
+  '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+  '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+  '</Types>';
+
+const buildRootRelsXml = () =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>' +
+  '</Relationships>';
+
+const buildWorkbookRelsXml = () =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' +
+  '</Relationships>';
+
+const buildXlsxFile = (columns: ExportColumn[], rows: string[][], sheetName: string) => {
+  const safeSheetName = sheetName.replace(/[\\/:*?\[\]]/g, '').substring(0, 31) || 'Export';
+  const sheetXml = buildSheetXml(columns, rows);
+  const workbookXml = buildWorkbookXml(safeSheetName);
+  const contentTypesXml = buildContentTypesXml();
+  const rootRelsXml = buildRootRelsXml();
+  const workbookRelsXml = buildWorkbookRelsXml();
+
+  const entries: ZipEntry[] = [
+    { path: '[Content_Types].xml', data: textEncoder.encode(contentTypesXml) },
+    { path: '_rels/.rels', data: textEncoder.encode(rootRelsXml) },
+    { path: 'xl/workbook.xml', data: textEncoder.encode(workbookXml) },
+    { path: 'xl/_rels/workbook.xml.rels', data: textEncoder.encode(workbookRelsXml) },
+    { path: 'xl/worksheets/sheet1.xml', data: textEncoder.encode(sheetXml) }
+  ];
+
+  return createZip(entries);
+};
+
+const buildCsv = (columns: ExportColumn[], rows: string[][]) => {
+  const header = columns.map((column) => `"${column.header.replace(/"/g, '""')}"`).join(',');
+  const body = rows
+    .map((row) =>
+      row
+        .map((value) => {
+          const needsQuotes = /[",\n]/.test(value);
+          const safe = value.replace(/"/g, '""');
+          return needsQuotes ? `"${safe}"` : safe;
+        })
+        .join(',')
+    )
+    .join('\r\n');
+  return `${header}${rows.length ? '\r\n' : ''}${body}`;
+};
+
+const chunkLines = (lines: string[], maxLinesPerPage: number) => {
+  const pages: string[][] = [];
+  for (let index = 0; index < lines.length; index += maxLinesPerPage) {
+    pages.push(lines.slice(index, index + maxLinesPerPage));
+  }
+  return pages;
+};
+
+const buildPdf = (title: string, columns: ExportColumn[], rows: string[][]) => {
+  const colWidths = columns.map((column, index) => {
+    const columnValues = rows.map((row) => row[index] ?? '');
+    const maxLength = Math.max(column.header.length, ...columnValues.map((value) => value.length));
+    return Math.min(Math.max(maxLength + 2, 8), 40);
+  });
+
+  const headerLine = columns
+    .map((column, index) => padEnd(column.header.toUpperCase(), colWidths[index]))
+    .join(' ');
+
+  const bodyLines = rows.map((row) =>
+    row.map((value, index) => padEnd(value, colWidths[index])).join(' ')
+  );
+
+  const lines = [title, ''.padEnd(headerLine.length, '='), headerLine, ''.padEnd(headerLine.length, '-')];
+  lines.push(...bodyLines);
+
+  const lineHeight = 14;
+  const topMargin = 780;
+  const bottomMargin = 60;
+  const usableHeight = topMargin - bottomMargin;
+  const maxLinesPerPage = Math.max(1, Math.floor(usableHeight / lineHeight));
+  const pages = chunkLines(lines, maxLinesPerPage);
+
+  const objects: string[] = [];
+  const pageReferences: Array<{ pageId: number; contentId: number }> = [];
+
+  const catalogId = 1;
+  const pagesId = 2;
+  const fontId = 3;
+
+  pages.forEach((pageLines, index) => {
+    const contentParts = pageLines.map((line, lineIndex) => {
+      const y = topMargin - lineIndex * lineHeight - 40;
+      return `BT /F1 10 Tf 1 0 0 1 40 ${y} Tm (${escapePdfText(line)}) Tj ET`;
+    });
+    const content = contentParts.join('\n');
+    const contentStream = `<< /Length ${content.length} >>\nstream\n${content}\nendstream`;
+    const contentId = 4 + index * 2;
+    const pageId = contentId + 1;
+    objects[contentId] = contentStream;
+    const pageObject =
+      `<< /Type /Page /Parent ${pagesId} 0 R /MediaBox [0 0 612 792] /Contents ${contentId} 0 R /Resources << /Font << /F1 ${fontId} 0 R >> >> >>`;
+    objects[pageId] = pageObject;
+    pageReferences.push({ pageId, contentId });
+  });
+
+  const kids = pageReferences.map(({ pageId }) => `${pageId} 0 R`).join(' ');
+  objects[catalogId] = `<< /Type /Catalog /Pages ${pagesId} 0 R >>`;
+  objects[pagesId] = `<< /Type /Pages /Count ${pages.length} /Kids [ ${kids} ] >>`;
+  objects[fontId] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+
+  const objectCount = objects.length - 1;
+  const header = '%PDF-1.4\n';
+  let body = '';
+  const offsets: number[] = [0];
+  let currentOffset = header.length;
+
+  for (let id = 1; id <= objectCount; id += 1) {
+    const objectContent = objects[id];
+    if (!objectContent) {
+      continue;
+    }
+    const serialized = `${id} 0 obj\n${objectContent}\nendobj\n`;
+    body += serialized;
+    offsets[id] = currentOffset;
+    currentOffset += serialized.length;
+  }
+
+  const xrefOffset = header.length + body.length;
+  let xref = `xref\n0 ${objectCount + 1}\n0000000000 65535 f \n`;
+  for (let id = 1; id <= objectCount; id += 1) {
+    const offset = offsets[id] ?? header.length;
+    xref += `${offset.toString().padStart(10, '0')} 00000 n \n`;
+  }
+
+  const trailer = `trailer\n<< /Size ${objectCount + 1} /Root ${catalogId} 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+  const pdfContent = header + body + xref + trailer;
+  return textEncoder.encode(pdfContent);
+};
+
+const openPrintWindow = (title: string, columns: ExportColumn[], rows: string[][]) => {
+  const htmlRows = rows
+    .map((row) => `<tr>${row.map((value) => `<td style="padding:8px;border:1px solid #d1d5db;font-size:12px;">${value}</td>`).join('')}</tr>`)
+    .join('');
+
+  const html = `<!DOCTYPE html><html><head><meta charset="utf-8" />` +
+    `<title>${title}</title>` +
+    '<style>body{font-family:Arial,sans-serif;padding:24px;}table{border-collapse:collapse;width:100%;}thead th{background:#f1f5f9;border:1px solid #d1d5db;padding:8px;text-align:left;font-size:12px;text-transform:uppercase;letter-spacing:0.05em;}</style>' +
+    '</head><body>' +
+    `<h1 style="font-size:20px;margin-bottom:16px;">${title}</h1>` +
+    `<table><thead><tr>${columns
+      .map((column) => `<th>${column.header}</th>`)
+      .join('')}</tr></thead><tbody>${htmlRows}</tbody></table></body></html>`;
+
+  const printWindow = window.open('', '_blank');
+  if (printWindow) {
+    printWindow.document.write(html);
+    printWindow.document.close();
+    printWindow.focus();
+  }
+};
+
+const formatValue = (value: string | number | boolean | null | undefined): string => {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
+  return value;
+};
+
+const sanitizeFileName = (value: string) =>
+  value
+    .trim()
+    .replace(/[^a-z0-9\-]+/gi, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase() || 'export';
+
+const downloadBlob = (blob: Blob, fileName: string) => {
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+  link.href = url;
+  link.download = fileName;
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+export interface ExportOptions {
+  format: ExportFormat;
+  columns: ExportColumn[];
+  rows: ExportRow[];
+  fileName: string;
+  title?: string;
+}
+
+export const exportDataset = ({ format, columns, rows, fileName, title }: ExportOptions) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const normalizedRows = rows.map((row) => columns.map((column) => formatValue(row[column.key])));
+  const safeFileName = sanitizeFileName(fileName);
+  const sheetTitle = title ?? fileName;
+
+  switch (format) {
+    case 'xlsx': {
+      const workbook = buildXlsxFile(columns, normalizedRows, sheetTitle);
+      const blob = new Blob([toArrayBuffer(workbook)], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+      });
+      downloadBlob(blob, `${safeFileName}.xlsx`);
+      break;
+    }
+    case 'csv': {
+      const csv = buildCsv(columns, normalizedRows);
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      downloadBlob(blob, `${safeFileName}.csv`);
+      break;
+    }
+    case 'pdf': {
+      const pdfBytes = buildPdf(sheetTitle, columns, normalizedRows);
+      const blob = new Blob([toArrayBuffer(pdfBytes)], { type: 'application/pdf' });
+      downloadBlob(blob, `${safeFileName}.pdf`);
+      break;
+    }
+    case 'print': {
+      openPrintWindow(sheetTitle, columns, normalizedRows);
+      break;
+    }
+    default:
+      break;
+  }
+};
+

--- a/frontend/src/utils/permissionGroups.ts
+++ b/frontend/src/utils/permissionGroups.ts
@@ -1,0 +1,149 @@
+import type { Permission } from '../types/models';
+
+export type CapabilitySlot =
+  | 'viewOwn'
+  | 'viewGlobal'
+  | 'view'
+  | 'create'
+  | 'edit'
+  | 'delete'
+  | 'export'
+  | 'manage'
+  | 'assign';
+
+export type PermissionOption = {
+  id: number;
+  key: string;
+  label: string;
+};
+
+export type PermissionGroup = {
+  feature: string;
+  slots: Partial<Record<CapabilitySlot, PermissionOption>>;
+  extras: PermissionOption[];
+};
+
+export const CAPABILITY_COLUMNS: Array<{ slot: CapabilitySlot; label: string }> = [
+  { slot: 'viewOwn', label: 'View (Own)' },
+  { slot: 'viewGlobal', label: 'View (Global)' },
+  { slot: 'view', label: 'View' },
+  { slot: 'create', label: 'Create' },
+  { slot: 'edit', label: 'Edit' },
+  { slot: 'delete', label: 'Delete' },
+  { slot: 'export', label: 'Export' },
+  { slot: 'manage', label: 'Manage' },
+  { slot: 'assign', label: 'Assign' }
+];
+
+const CAPABILITY_PATTERNS: Array<{ slot: CapabilitySlot; regex: RegExp }> = [
+  { slot: 'viewGlobal', regex: /_VIEW_GLOBAL$/i },
+  { slot: 'viewOwn', regex: /_VIEW_OWN$/i },
+  { slot: 'view', regex: /_VIEW$/i },
+  { slot: 'create', regex: /_CREATE$/i },
+  { slot: 'edit', regex: /_EDIT$/i },
+  { slot: 'edit', regex: /_UPDATE$/i },
+  { slot: 'delete', regex: /_DELETE$/i },
+  { slot: 'export', regex: /_EXPORT$/i },
+  { slot: 'manage', regex: /_MANAGE$/i },
+  { slot: 'assign', regex: /_ASSIGN$/i }
+];
+
+const toTitleCase = (value: string) =>
+  value
+    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.substring(1).toLowerCase());
+
+const formatFeatureName = (value: string) =>
+  value
+    .split(/[_\s]+/g)
+    .filter(Boolean)
+    .map((segment) => (segment.length <= 3 ? segment.toUpperCase() : segment.charAt(0).toUpperCase() + segment.substring(1).toLowerCase()))
+    .join(' ');
+
+const stripCapabilitySuffix = (key: string) => {
+  for (const pattern of CAPABILITY_PATTERNS) {
+    if (pattern.regex.test(key)) {
+      return key.replace(pattern.regex, '');
+    }
+  }
+  return key;
+};
+
+const parsePermissionLabel = (permission: Permission) => {
+  const name = permission.name?.trim() ?? '';
+  const separators = [':', ' - ', ' – ', ' — ', '|'];
+
+  for (const separator of separators) {
+    if (name.includes(separator)) {
+      const [featureRaw, ...rest] = name.split(separator);
+      const feature = formatFeatureName(featureRaw);
+      const label = rest.join(separator).trim();
+      if (feature && label) {
+        return { feature, label: label || permission.key };
+      }
+    }
+  }
+
+  if (name) {
+    const words = name.split(/\s+/g).filter(Boolean);
+    if (words.length > 1) {
+      const verbs = new Set(['view', 'create', 'update', 'edit', 'delete', 'manage', 'assign', 'export']);
+      const [first, ...rest] = words;
+      if (verbs.has(first.toLowerCase())) {
+        return { feature: formatFeatureName(rest.join(' ')), label: name };
+      }
+    }
+    return { feature: formatFeatureName(name), label: name };
+  }
+
+  const baseKey = stripCapabilitySuffix(permission.key);
+  const feature = formatFeatureName(baseKey || permission.key);
+  const label = permission.name?.trim() ?? toTitleCase(permission.key.replace(/_/g, ' '));
+  return { feature, label };
+};
+
+export const buildPermissionGroups = (permissions: Permission[]): PermissionGroup[] => {
+  const map = new Map<string, PermissionGroup>();
+
+  permissions.forEach((permission) => {
+    const { feature, label } = parsePermissionLabel(permission);
+    const key = feature || 'General';
+    const existing = map.get(key);
+    const entry: PermissionGroup = existing ?? { feature: key, slots: {}, extras: [] };
+
+    let matchedSlot: CapabilitySlot | null = null;
+    for (const pattern of CAPABILITY_PATTERNS) {
+      if (pattern.regex.test(permission.key)) {
+        matchedSlot = pattern.slot;
+        break;
+      }
+    }
+
+    const option: PermissionOption = {
+      id: permission.id,
+      key: permission.key,
+      label: label || permission.name || permission.key
+    };
+
+    if (matchedSlot) {
+      if (!entry.slots[matchedSlot]) {
+        entry.slots[matchedSlot] = option;
+      } else {
+        entry.extras.push(option);
+      }
+    } else {
+      entry.extras.push(option);
+    }
+
+    map.set(key, entry);
+  });
+
+  return Array.from(map.values())
+    .map((group) => ({
+      ...group,
+      extras: group.extras.sort((a, b) => a.label.localeCompare(b.label))
+    }))
+    .sort((a, b) => a.feature.localeCompare(b.feature));
+};

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -1,13 +1,56 @@
 import type { PermissionKey } from '../types/auth';
 
+const normalizeViewPermission = (permission: PermissionKey) => {
+  if (/_VIEW_(OWN|GLOBAL)$/i.test(permission)) {
+    return permission.replace(/_(OWN|GLOBAL)$/i, '');
+  }
+  return permission;
+};
+
 export const hasAnyPermission = (userPermissions: PermissionKey[], required: PermissionKey[]): boolean => {
-  return required.some((permission) => userPermissions.includes(permission));
+  if (!userPermissions?.length || !required?.length) {
+    return false;
+  }
+
+  const userSet = new Set(userPermissions);
+  return required.some((permission) => {
+    if (userSet.has(permission)) {
+      return true;
+    }
+
+    if (/_VIEW$/i.test(permission)) {
+      const normalized = normalizeViewPermission(permission);
+      for (const userPermission of userSet) {
+        if (normalizeViewPermission(userPermission) === normalized) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  });
 };
 
 export const TAB_RULES: Record<string, PermissionKey[]> = {
-  Users: ['USER_VIEW', 'USER_CREATE', 'USER_UPDATE', 'USER_DELETE'],
-  Roles: ['ROLE_VIEW', 'ROLE_CREATE', 'ROLE_UPDATE', 'ROLE_DELETE'],
-  Permissions: ['PERMISSION_VIEW', 'PERMISSION_CREATE', 'PERMISSION_UPDATE', 'PERMISSION_DELETE'],
-  Customers: ['CUSTOMER_VIEW', 'CUSTOMER_CREATE', 'CUSTOMER_UPDATE', 'CUSTOMER_DELETE'],
-  Invoices: ['INVOICE_VIEW', 'INVOICE_CREATE', 'INVOICE_UPDATE', 'INVOICE_DELETE']
+  Users: [
+    'USER_VIEW',
+    'USER_VIEW_GLOBAL',
+    'USER_VIEW_OWN',
+    'CUSTOMER_VIEW',
+    'CUSTOMER_VIEW_GLOBAL',
+    'CUSTOMER_VIEW_OWN',
+    'CUSTOMER_CREATE',
+    'CUSTOMER_UPDATE',
+    'CUSTOMER_DELETE'
+  ],
+  Roles: ['ROLE_VIEW'],
+  Permissions: ['PERMISSION_VIEW'],
+  Invoices: [
+    'INVOICE_VIEW',
+    'INVOICE_VIEW_GLOBAL',
+    'INVOICE_VIEW_OWN',
+    'INVOICE_CREATE',
+    'INVOICE_UPDATE',
+    'INVOICE_DELETE'
+  ]
 };

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,0 +1,33 @@
+export const safeLocalStorage = {
+  getItem(key: string): string | null {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    try {
+      return window.localStorage.getItem(key);
+    } catch (error) {
+      console.warn('Unable to read from localStorage:', error);
+      return null;
+    }
+  },
+  setItem(key: string, value: string) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (error) {
+      console.warn('Unable to write to localStorage:', error);
+    }
+  },
+  removeItem(key: string) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.removeItem(key);
+    } catch (error) {
+      console.warn('Unable to remove from localStorage:', error);
+    }
+  }
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { webcrypto } from 'node:crypto';
+
+if (typeof globalThis.crypto === 'undefined' || typeof globalThis.crypto.getRandomValues !== 'function') {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true
+  });
+}
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- add per-user permission revocations in the backend data model, service layer, and Flyway migrations so effective authorities subtract revoked scopes
- propagate revoked permissions through auth responses, client state, and the users management UI while differentiating direct overrides vs inherited capabilities
- hide destructive customer and invoice actions without the matching permissions, ensure invoice editing is available to authorized users, and enforce controller-level permission gates on those endpoints
- introduce export-specific permissions, dropdown menus, and multi-format (Excel, CSV, PDF, print) exports across the users, roles, permissions, and invoices directories while gating access in the UI
- restore the original V2 seed migration checksum and add a new migration that inserts export permissions so existing databases start cleanly

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e15a519f1c8323a3de70807529661f