### PR TITLE
Add activity monitoring module with audit UI

### DIFF
--- a/backend/src/main/java/com/example/rbac/activity/controller/ActivityController.java
+++ b/backend/src/main/java/com/example/rbac/activity/controller/ActivityController.java
@@ -1,0 +1,74 @@
+package com.example.rbac.activity.controller;
+
+import com.example.rbac.activity.dto.ActivityFilterOptionsDto;
+import com.example.rbac.activity.dto.ActivityLogDetailDto;
+import com.example.rbac.activity.dto.ActivityLogDto;
+import com.example.rbac.activity.dto.ActivityLogFilter;
+import com.example.rbac.activity.service.ActivityLogService;
+import com.example.rbac.common.pagination.PageResponse;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/activity")
+public class ActivityController {
+
+    private final ActivityLogService activityLogService;
+
+    public ActivityController(ActivityLogService activityLogService) {
+        this.activityLogService = activityLogService;
+    }
+
+    @GetMapping
+    public PageResponse<ActivityLogDto> search(@RequestParam(name = "page", defaultValue = "0") int page,
+                                               @RequestParam(name = "size", defaultValue = "25") int size,
+                                               @RequestParam(name = "sort", defaultValue = "timestamp") String sort,
+                                               @RequestParam(name = "direction", defaultValue = "desc") String direction,
+                                               @RequestParam(name = "search", required = false) String search,
+                                               @RequestParam(name = "user", required = false) String user,
+                                               @RequestParam(name = "role", required = false) List<String> roles,
+                                               @RequestParam(name = "department", required = false) List<String> departments,
+                                               @RequestParam(name = "module", required = false) List<String> modules,
+                                               @RequestParam(name = "type", required = false) List<String> types,
+                                               @RequestParam(name = "status", required = false) List<String> statuses,
+                                               @RequestParam(name = "ipAddress", required = false) List<String> ipAddresses,
+                                               @RequestParam(name = "device", required = false) List<String> devices,
+                                               @RequestParam(name = "startDate", required = false)
+                                               @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                               OffsetDateTime startDate,
+                                               @RequestParam(name = "endDate", required = false)
+                                               @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                               OffsetDateTime endDate) {
+        ActivityLogFilter filter = new ActivityLogFilter(
+                search,
+                user,
+                roles,
+                departments,
+                modules,
+                types,
+                statuses,
+                ipAddresses,
+                devices,
+                startDate != null ? startDate.toInstant() : null,
+                endDate != null ? endDate.toInstant() : null
+        );
+        return activityLogService.search(page, size, sort, direction, filter);
+    }
+
+    @GetMapping("/{id}")
+    public ActivityLogDetailDto getDetail(@PathVariable("id") Long id) {
+        return activityLogService.getDetail(id);
+    }
+
+    @GetMapping("/filters")
+    public ActivityFilterOptionsDto getFilters() {
+        return activityLogService.getFilterOptions();
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityFilterOptionsDto.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityFilterOptionsDto.java
@@ -1,0 +1,14 @@
+package com.example.rbac.activity.dto;
+
+import java.util.List;
+
+public record ActivityFilterOptionsDto(
+        List<String> activityTypes,
+        List<String> modules,
+        List<String> statuses,
+        List<String> roles,
+        List<String> departments,
+        List<String> ipAddresses,
+        List<String> devices
+) {
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDetailDto.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDetailDto.java
@@ -1,0 +1,22 @@
+package com.example.rbac.activity.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ActivityLogDetailDto(
+        Long id,
+        Instant occurredAt,
+        Long userId,
+        String userName,
+        String userRole,
+        String department,
+        String module,
+        String activityType,
+        String description,
+        String status,
+        String ipAddress,
+        String device,
+        Map<String, Object> context,
+        String rawContext
+) {
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDto.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDto.java
@@ -1,0 +1,19 @@
+package com.example.rbac.activity.dto;
+
+import java.time.Instant;
+
+public record ActivityLogDto(
+        Long id,
+        Instant occurredAt,
+        Long userId,
+        String userName,
+        String userRole,
+        String department,
+        String module,
+        String activityType,
+        String description,
+        String status,
+        String ipAddress,
+        String device
+) {
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogFilter.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogFilter.java
@@ -1,0 +1,49 @@
+package com.example.rbac.activity.dto;
+
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record ActivityLogFilter(
+        String search,
+        String user,
+        List<String> roles,
+        List<String> departments,
+        List<String> modules,
+        List<String> activityTypes,
+        List<String> statuses,
+        List<String> ipAddresses,
+        List<String> devices,
+        Instant startDate,
+        Instant endDate
+) {
+    public ActivityLogFilter {
+        search = normalizeText(search);
+        user = normalizeText(user);
+        roles = normalizeList(roles);
+        departments = normalizeList(departments);
+        modules = normalizeList(modules);
+        activityTypes = normalizeList(activityTypes);
+        statuses = normalizeList(statuses);
+        ipAddresses = normalizeList(ipAddresses);
+        devices = normalizeList(devices);
+    }
+
+    private static String normalizeText(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private static List<String> normalizeList(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return values.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.collectingAndThen(Collectors.toList(), List::copyOf));
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/mapper/ActivityLogMapper.java
+++ b/backend/src/main/java/com/example/rbac/activity/mapper/ActivityLogMapper.java
@@ -1,0 +1,73 @@
+package com.example.rbac.activity.mapper;
+
+import com.example.rbac.activity.dto.ActivityLogDetailDto;
+import com.example.rbac.activity.dto.ActivityLogDto;
+import com.example.rbac.activity.model.ActivityLog;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class ActivityLogMapper {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+
+    public ActivityLogMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public ActivityLogDto toDto(ActivityLog log) {
+        if (log == null) {
+            return null;
+        }
+        return new ActivityLogDto(
+                log.getId(),
+                log.getOccurredAt(),
+                log.getUserId(),
+                log.getUserName(),
+                log.getUserRole(),
+                log.getDepartment(),
+                log.getModuleName(),
+                log.getActivityType(),
+                log.getDescription(),
+                log.getStatus(),
+                log.getIpAddress(),
+                log.getDevice()
+        );
+    }
+
+    public ActivityLogDetailDto toDetail(ActivityLog log) {
+        if (log == null) {
+            return null;
+        }
+        Map<String, Object> context = null;
+        if (log.getContext() != null) {
+            try {
+                context = objectMapper.readValue(log.getContext(), MAP_TYPE);
+            } catch (JsonProcessingException ignored) {
+                context = null;
+            }
+        }
+        return new ActivityLogDetailDto(
+                log.getId(),
+                log.getOccurredAt(),
+                log.getUserId(),
+                log.getUserName(),
+                log.getUserRole(),
+                log.getDepartment(),
+                log.getModuleName(),
+                log.getActivityType(),
+                log.getDescription(),
+                log.getStatus(),
+                log.getIpAddress(),
+                log.getDevice(),
+                context,
+                log.getContext()
+        );
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/model/ActivityLog.java
+++ b/backend/src/main/java/com/example/rbac/activity/model/ActivityLog.java
@@ -1,0 +1,161 @@
+package com.example.rbac.activity.model;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "activity_logs")
+public class ActivityLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "user_name", nullable = false, length = 150)
+    private String userName;
+
+    @Column(name = "user_role", length = 150)
+    private String userRole;
+
+    @Column(length = 150)
+    private String department;
+
+    @Column(name = "module_name", length = 150)
+    private String moduleName;
+
+    @Column(name = "activity_type", nullable = false, length = 100)
+    private String activityType;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(length = 50)
+    private String status;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(length = 150)
+    private String device;
+
+    @Column(name = "context", columnDefinition = "TEXT")
+    private String context;
+
+    @PrePersist
+    public void prePersist() {
+        if (occurredAt == null) {
+            occurredAt = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(Instant occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(String userRole) {
+        this.userRole = userRole;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public String getActivityType() {
+        return activityType;
+    }
+
+    public void setActivityType(String activityType) {
+        this.activityType = activityType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getDevice() {
+        return device;
+    }
+
+    public void setDevice(String device) {
+        this.device = device;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/repository/ActivityLogRepository.java
+++ b/backend/src/main/java/com/example/rbac/activity/repository/ActivityLogRepository.java
@@ -1,0 +1,34 @@
+package com.example.rbac.activity.repository;
+
+import com.example.rbac.activity.model.ActivityLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long>, JpaSpecificationExecutor<ActivityLog> {
+
+    @Query("select distinct a.activityType from ActivityLog a where a.activityType is not null order by lower(a.activityType)")
+    List<String> findDistinctActivityTypes();
+
+    @Query("select distinct a.moduleName from ActivityLog a where a.moduleName is not null order by lower(a.moduleName)")
+    List<String> findDistinctModules();
+
+    @Query("select distinct a.status from ActivityLog a where a.status is not null order by lower(a.status)")
+    List<String> findDistinctStatuses();
+
+    @Query("select distinct a.userRole from ActivityLog a where a.userRole is not null order by lower(a.userRole)")
+    List<String> findDistinctRoles();
+
+    @Query("select distinct a.department from ActivityLog a where a.department is not null order by lower(a.department)")
+    List<String> findDistinctDepartments();
+
+    @Query("select distinct a.ipAddress from ActivityLog a where a.ipAddress is not null order by a.ipAddress")
+    List<String> findDistinctIpAddresses();
+
+    @Query("select distinct a.device from ActivityLog a where a.device is not null order by lower(a.device)")
+    List<String> findDistinctDevices();
+}

--- a/backend/src/main/java/com/example/rbac/activity/service/ActivityLogService.java
+++ b/backend/src/main/java/com/example/rbac/activity/service/ActivityLogService.java
@@ -1,0 +1,120 @@
+package com.example.rbac.activity.service;
+
+import com.example.rbac.activity.dto.ActivityFilterOptionsDto;
+import com.example.rbac.activity.dto.ActivityLogDetailDto;
+import com.example.rbac.activity.dto.ActivityLogDto;
+import com.example.rbac.activity.dto.ActivityLogFilter;
+import com.example.rbac.activity.mapper.ActivityLogMapper;
+import com.example.rbac.activity.model.ActivityLog;
+import com.example.rbac.activity.repository.ActivityLogRepository;
+import com.example.rbac.activity.spec.ActivityLogSpecifications;
+import com.example.rbac.common.exception.ApiException;
+import com.example.rbac.common.pagination.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class ActivityLogService {
+
+    private static final Map<String, String> SORT_MAPPING;
+
+    static {
+        SORT_MAPPING = new HashMap<>();
+        SORT_MAPPING.put("timestamp", "occurredAt");
+        SORT_MAPPING.put("user", "userName");
+        SORT_MAPPING.put("activityType", "activityType");
+        SORT_MAPPING.put("module", "moduleName");
+        SORT_MAPPING.put("status", "status");
+    }
+
+    private final ActivityLogRepository activityLogRepository;
+    private final ActivityLogMapper activityLogMapper;
+
+    public ActivityLogService(ActivityLogRepository activityLogRepository,
+                              ActivityLogMapper activityLogMapper) {
+        this.activityLogRepository = activityLogRepository;
+        this.activityLogMapper = activityLogMapper;
+    }
+
+    @PreAuthorize("hasAuthority('ACTIVITY_VIEW')")
+    @Transactional(readOnly = true)
+    public PageResponse<ActivityLogDto> search(int page,
+                                               int size,
+                                               String sort,
+                                               String direction,
+                                               ActivityLogFilter filter) {
+        Pageable pageable = buildPageable(page, size, sort, direction);
+        Specification<ActivityLog> specification = buildSpecification(filter);
+        Page<ActivityLogDto> result = activityLogRepository.findAll(specification, pageable)
+                .map(activityLogMapper::toDto);
+        return PageResponse.from(result);
+    }
+
+    @PreAuthorize("hasAuthority('ACTIVITY_VIEW')")
+    @Transactional(readOnly = true)
+    public ActivityLogDetailDto getDetail(Long id) {
+        ActivityLog log = activityLogRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Activity not found"));
+        return activityLogMapper.toDetail(log);
+    }
+
+    @PreAuthorize("hasAuthority('ACTIVITY_VIEW')")
+    @Transactional(readOnly = true)
+    public ActivityFilterOptionsDto getFilterOptions() {
+        return new ActivityFilterOptionsDto(
+                activityLogRepository.findDistinctActivityTypes(),
+                activityLogRepository.findDistinctModules(),
+                activityLogRepository.findDistinctStatuses(),
+                activityLogRepository.findDistinctRoles(),
+                activityLogRepository.findDistinctDepartments(),
+                activityLogRepository.findDistinctIpAddresses(),
+                activityLogRepository.findDistinctDevices()
+        );
+    }
+
+    private Pageable buildPageable(int page, int size, String sort, String direction) {
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.min(Math.max(size, 1), 200);
+        String normalizedSort = sort == null ? "timestamp" : sort.toLowerCase();
+        String property = SORT_MAPPING.getOrDefault(normalizedSort, SORT_MAPPING.get("timestamp"));
+        Sort.Direction sortDirection = "asc".equalsIgnoreCase(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        return PageRequest.of(safePage, safeSize, Sort.by(sortDirection, property));
+    }
+
+    private Specification<ActivityLog> buildSpecification(ActivityLogFilter filter) {
+        Specification<ActivityLog> spec = Specification.where(null);
+        spec = combine(spec, ActivityLogSpecifications.searchTerm(filter.search()));
+        spec = combine(spec, ActivityLogSpecifications.userQuery(filter.user()));
+        spec = combine(spec, ActivityLogSpecifications.roles(filter.roles()));
+        spec = combine(spec, ActivityLogSpecifications.departments(filter.departments()));
+        spec = combine(spec, ActivityLogSpecifications.modules(filter.modules()));
+        spec = combine(spec, ActivityLogSpecifications.activityTypes(filter.activityTypes()));
+        spec = combine(spec, ActivityLogSpecifications.statuses(filter.statuses()));
+        spec = combine(spec, ActivityLogSpecifications.ipAddresses(filter.ipAddresses()));
+        spec = combine(spec, ActivityLogSpecifications.devices(filter.devices()));
+        spec = combine(spec, ActivityLogSpecifications.occurredAfter(filter.startDate()));
+        spec = combine(spec, ActivityLogSpecifications.occurredBefore(filter.endDate()));
+        return spec;
+    }
+
+    private Specification<ActivityLog> combine(Specification<ActivityLog> base,
+                                               Specification<ActivityLog> addition) {
+        if (base == null) {
+            return addition;
+        }
+        if (addition == null) {
+            return base;
+        }
+        return base.and(addition);
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/spec/ActivityLogSpecifications.java
+++ b/backend/src/main/java/com/example/rbac/activity/spec/ActivityLogSpecifications.java
@@ -1,0 +1,144 @@
+package com.example.rbac.activity.spec;
+
+import com.example.rbac.activity.model.ActivityLog;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class ActivityLogSpecifications {
+
+    private ActivityLogSpecifications() {
+    }
+
+    public static Specification<ActivityLog> searchTerm(String term) {
+        if (!StringUtils.hasText(term)) {
+            return null;
+        }
+        final String pattern = "%" + term.trim().toLowerCase() + "%";
+        return (root, query, builder) -> builder.or(
+                builder.like(builder.lower(root.get("description")), pattern),
+                builder.like(builder.lower(root.get("moduleName")), pattern),
+                builder.like(builder.lower(root.get("activityType")), pattern),
+                builder.like(builder.lower(root.get("userName")), pattern),
+                builder.like(builder.lower(root.get("ipAddress")), pattern),
+                builder.like(builder.lower(root.get("device")), pattern)
+        );
+    }
+
+    public static Specification<ActivityLog> userQuery(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        final String trimmed = value.trim();
+        final String pattern = "%" + trimmed.toLowerCase() + "%";
+        final boolean numeric = trimmed.chars().allMatch(Character::isDigit);
+        return (root, query, builder) -> {
+            if (numeric) {
+                Long userId;
+                try {
+                    userId = Long.parseLong(trimmed);
+                } catch (NumberFormatException ex) {
+                    userId = null;
+                }
+                if (userId != null) {
+                    return builder.or(
+                            builder.equal(root.get("userId"), userId),
+                            builder.like(builder.lower(root.get("userName")), pattern)
+                    );
+                }
+            }
+            return builder.like(builder.lower(root.get("userName")), pattern);
+        };
+    }
+
+    public static Specification<ActivityLog> roles(Collection<String> roles) {
+        List<String> normalized = normalizeUpperList(roles);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("userRole")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> departments(Collection<String> departments) {
+        List<String> normalized = normalizeUpperList(departments);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("department")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> modules(Collection<String> modules) {
+        List<String> normalized = normalizeUpperList(modules);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("moduleName")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> activityTypes(Collection<String> types) {
+        List<String> normalized = normalizeUpperList(types);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("activityType")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> statuses(Collection<String> statuses) {
+        List<String> normalized = normalizeUpperList(statuses);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("status")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> ipAddresses(Collection<String> ipAddresses) {
+        List<String> normalized = normalizeList(ipAddresses);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> root.get("ipAddress").in(normalized);
+    }
+
+    public static Specification<ActivityLog> devices(Collection<String> devices) {
+        List<String> normalized = normalizeUpperList(devices);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("device")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> occurredAfter(Instant start) {
+        if (start == null) {
+            return null;
+        }
+        return (root, query, builder) -> builder.greaterThanOrEqualTo(root.get("occurredAt"), start);
+    }
+
+    public static Specification<ActivityLog> occurredBefore(Instant end) {
+        if (end == null) {
+            return null;
+        }
+        return (root, query, builder) -> builder.lessThanOrEqualTo(root.get("occurredAt"), end);
+    }
+
+    private static List<String> normalizeUpperList(Collection<String> values) {
+        return normalizeList(values).stream()
+                .map(value -> value.toUpperCase())
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> normalizeList(Collection<String> values) {
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/resources/db/migration/V9__activity_module.sql
+++ b/backend/src/main/resources/db/migration/V9__activity_module.sql
@@ -1,0 +1,81 @@
+CREATE TABLE activity_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    occurred_at DATETIME(6) NOT NULL,
+    user_id BIGINT NULL,
+    user_name VARCHAR(150) NOT NULL,
+    user_role VARCHAR(150) NULL,
+    department VARCHAR(150) NULL,
+    module_name VARCHAR(150) NULL,
+    activity_type VARCHAR(100) NOT NULL,
+    description VARCHAR(1000) NULL,
+    status VARCHAR(50) NULL,
+    ip_address VARCHAR(45) NULL,
+    device VARCHAR(150) NULL,
+    context TEXT NULL
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_activity_logs_occurred_at ON activity_logs (occurred_at);
+CREATE INDEX idx_activity_logs_module ON activity_logs (module_name);
+CREATE INDEX idx_activity_logs_activity_type ON activity_logs (activity_type);
+CREATE INDEX idx_activity_logs_status ON activity_logs (status);
+
+INSERT INTO activity_logs (
+    occurred_at,
+    user_id,
+    user_name,
+    user_role,
+    department,
+    module_name,
+    activity_type,
+    description,
+    status,
+    ip_address,
+    device,
+    context
+) VALUES
+('2024-03-18 09:12:35', 1, 'Super Admin', 'SUPER_ADMIN', 'Operations', 'Users', 'UPDATE',
+ 'Updated permissions for user "finance@demo.io" to include invoice export rights.', 'SUCCESS', '192.168.1.10', 'Chrome on macOS',
+ '{"before": {"permissions": ["INVOICE_VIEW", "INVOICE_UPDATE"]}, "after": {"permissions": ["INVOICE_VIEW", "INVOICE_UPDATE", "INVOICES_EXPORT"]}}'),
+('2024-03-18 10:04:18', 2, 'Admin User', 'ADMIN', 'Customer Success', 'Customers', 'CREATE',
+ 'Created a new customer record for "Globex Manufacturing".', 'SUCCESS', '192.168.1.24', 'Edge on Windows',
+ '{"customer": {"name": "Globex Manufacturing", "email": "ops@globex.com"}}'),
+('2024-03-18 10:32:49', 3, 'Finance User', 'FINANCE', 'Accounting', 'Invoices', 'EXPORT',
+ 'Exported 24 invoices to CSV using the finance dashboard.', 'SUCCESS', '10.10.0.54', 'Safari on iPad',
+ '{"filters": {"status": "PAID", "from": "2024-02-01", "to": "2024-03-01"}, "format": "CSV"}'),
+('2024-03-18 11:14:02', 2, 'Admin User', 'ADMIN', 'Customer Success', 'Users', 'DISABLE',
+ 'Disabled login for user "contractor@demo.io" after contract end.', 'SUCCESS', '192.168.1.24', 'Edge on Windows',
+ '{"targetUser": "contractor@demo.io", "reason": "Contract expired"}'),
+('2024-03-18 12:06:41', 1, 'Super Admin', 'SUPER_ADMIN', 'Operations', 'Settings', 'UPDATE',
+ 'Updated the primary brand color to match new guidelines.', 'SUCCESS', '192.168.1.10', 'Chrome on macOS',
+ '{"before": {"appearance.primary_color": "#2563EB"}, "after": {"appearance.primary_color": "#1D4ED8"}}'),
+('2024-03-18 12:25:09', 4, 'API Client', 'SYSTEM', 'Integrations', 'Auth', 'LOGIN',
+ 'Service account authenticated using client credentials.', 'SUCCESS', '52.32.101.18', 'API Client',
+ '{"clientId": "svc-analytics", "scopes": ["analytics.read"]}'),
+('2024-03-18 13:17:32', 3, 'Finance User', 'FINANCE', 'Accounting', 'Invoices', 'UPDATE',
+ 'Adjusted invoice INV-1001 subtotal after reconciliation.', 'SUCCESS', '10.10.0.54', 'Safari on iPad',
+ '{"invoice": "INV-1001", "before": {"subtotal": 1500.00}, "after": {"subtotal": 1525.00}}'),
+('2024-03-18 14:02:11', 5, 'Security Monitor', 'SYSTEM', 'Security', 'Auth', 'LOGIN',
+ 'Failed login attempt detected for user "admin@demo.io".', 'FAILURE', '203.0.113.45', 'Firefox on Linux',
+ '{"username": "admin@demo.io", "result": "INVALID_PASSWORD"}'),
+('2024-03-18 14:48:27', 2, 'Admin User', 'ADMIN', 'Customer Success', 'Customers', 'UPDATE',
+ 'Updated billing contact information for "Soylent Industries".', 'SUCCESS', '192.168.1.24', 'Edge on Windows',
+ '{"customer": "Soylent Industries", "before": {"email": "finance@soylent.co"}, "after": {"email": "billing@soylent.co"}}'),
+('2024-03-18 15:36:55', 1, 'Super Admin', 'SUPER_ADMIN', 'Operations', 'Permissions', 'DELETE',
+ 'Removed legacy permission "REPORT_EXPORT" from the system.', 'SUCCESS', '192.168.1.10', 'Chrome on macOS',
+ '{"permission": "REPORT_EXPORT", "impact": "No active roles assigned."}');
+
+INSERT IGNORE INTO permissions (code, name) VALUES
+  ('ACTIVITY_VIEW', 'View Activity Log'),
+  ('ACTIVITY_EXPORT', 'Export Activity Log');
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code IN ('ACTIVITY_VIEW', 'ACTIVITY_EXPORT')
+WHERE r.code IN ('SUPER_ADMIN');
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code = 'ACTIVITY_VIEW'
+WHERE r.code IN ('ADMIN');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import SettingsPage from './pages/SettingsPage';
 import { fetchTheme } from './features/settings/settingsSlice';
 import { selectApplicationName, selectPrimaryColor } from './features/settings/selectors';
 import { applyPrimaryColor } from './utils/colors';
+import ActivityPage from './pages/ActivityPage';
+import ActivityDetailPage from './pages/ActivityDetailPage';
 
 const App = () => {
   const dispatch = useAppDispatch();
@@ -149,6 +151,10 @@ const App = () => {
             }
           >
             <Route path="/invoices" element={<InvoicesPage />} />
+          </Route>
+          <Route element={<PermissionRoute required={['ACTIVITY_VIEW']} />}>
+            <Route path="/activity" element={<ActivityPage />} />
+            <Route path="/activity/:id" element={<ActivityDetailPage />} />
           </Route>
           <Route element={<PermissionRoute required={['SETTINGS_VIEW']} />}>
             <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -90,6 +90,15 @@ const Layout = () => {
       });
     }
 
+    if (tabs.includes('Activity')) {
+      items.push({
+        key: 'activity',
+        label: 'Activity',
+        to: '/activity',
+        icon: '📝'
+      });
+    }
+
     if (tabs.includes('Settings')) {
       items.push({
         key: 'settings',

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -1,0 +1,189 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '../services/http';
+import type { ActivityLogDetail } from '../types/models';
+import { extractErrorMessage } from '../utils/errors';
+
+const formatDateTime = (value: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(value));
+
+const renderContextValue = (value: unknown) => {
+  if (Array.isArray(value)) {
+    if (!value.length) {
+      return <span className="text-sm text-slate-500">—</span>;
+    }
+    return (
+      <ul className="list-disc space-y-1 pl-5 text-sm text-slate-700">
+        {value.map((item, index) => (
+          <li key={index}>{renderContextValue(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (value && typeof value === 'object') {
+    return (
+      <pre className="whitespace-pre-wrap break-words rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  if (value === null || value === undefined) {
+    return <span className="text-sm text-slate-500">—</span>;
+  }
+
+  return <span className="text-sm text-slate-700">{String(value)}</span>;
+};
+
+const renderStatusBadge = (status?: string | null) => {
+  if (!status) {
+    return <span className="text-slate-400">—</span>;
+  }
+  const normalized = status.toUpperCase();
+  const isSuccess = normalized === 'SUCCESS';
+  const isFailure = normalized === 'FAILURE' || normalized === 'ERROR';
+  const badgeClass = isSuccess
+    ? 'bg-emerald-100 text-emerald-700'
+    : isFailure
+    ? 'bg-rose-100 text-rose-700'
+    : 'bg-slate-100 text-slate-700';
+  return <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${badgeClass}`}>{normalized}</span>;
+};
+
+const ActivityDetailPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+
+  const detailQuery = useQuery<ActivityLogDetail>({
+    queryKey: ['activity', 'detail', id],
+    enabled: Boolean(id),
+    queryFn: async () => {
+      const { data } = await api.get<ActivityLogDetail>(`/activity/${id}`);
+      return data;
+    }
+  });
+
+  const handleBack = () => {
+    navigate('/activity');
+  };
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center text-sm text-slate-500">
+        Loading activity details…
+      </div>
+    );
+  }
+
+  if (detailQuery.isError || !detailQuery.data) {
+    return (
+      <div className="space-y-6">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="inline-flex items-center gap-2 rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+        >
+          ← Back to Activity
+        </button>
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-600">
+          {extractErrorMessage(detailQuery.error, 'Unable to load the selected activity. It may have been removed.')}
+        </div>
+      </div>
+    );
+  }
+
+  const detail = detailQuery.data;
+
+  return (
+    <div className="space-y-6">
+      <button
+        type="button"
+        onClick={handleBack}
+        className="inline-flex items-center gap-2 rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+      >
+        ← Back to Activity
+      </button>
+
+      <div className="space-y-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800">Activity details</h1>
+          <p className="text-sm text-slate-500">
+            Review the complete metadata captured for this action.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Timestamp</div>
+            <div className="mt-1 text-sm font-medium text-slate-800">{formatDateTime(detail.occurredAt)}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Status</div>
+            <div className="mt-1">{renderStatusBadge(detail.status)}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">User</div>
+            <div className="mt-1 text-sm font-medium text-slate-800">{detail.userName}</div>
+            <div className="text-xs text-slate-500">{detail.userId ? `User ID: ${detail.userId}` : 'User ID not captured'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Role &amp; Department</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.userRole ?? '—'}</div>
+            <div className="text-xs text-slate-500">{detail.department ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Module</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.module ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Activity type</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.activityType}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">IP address</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.ipAddress ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Device</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.device ?? '—'}</div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs uppercase tracking-wide text-slate-400">Description</div>
+          <div className="mt-2 rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            {detail.description ?? 'No additional description provided.'}
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs uppercase tracking-wide text-slate-400">Context</div>
+          <div className="mt-2 space-y-3">
+            {detail.context && Object.keys(detail.context).length > 0 ? (
+              Object.entries(detail.context).map(([key, value]) => (
+                <div key={key}>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">{key}</div>
+                  <div className="mt-1">{renderContextValue(value)}</div>
+                </div>
+              ))
+            ) : detail.rawContext ? (
+              <pre className="whitespace-pre-wrap break-words rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
+                {detail.rawContext}
+              </pre>
+            ) : (
+              <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+                No contextual metadata recorded for this activity.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ActivityDetailPage;

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -1,0 +1,624 @@
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import DataTable from '../components/DataTable';
+import SortableColumnHeader from '../components/SortableColumnHeader';
+import ExportMenu from '../components/ExportMenu';
+import api from '../services/http';
+import { useAppSelector } from '../app/hooks';
+import { hasAnyPermission } from '../utils/permissions';
+import type { PermissionKey } from '../types/auth';
+import type { ActivityFilterOptions, ActivityLogEntry, Pagination } from '../types/models';
+import { extractErrorMessage } from '../utils/errors';
+import { useToast } from '../components/ToastProvider';
+import { exportDataset, type ExportFormat } from '../utils/exporters';
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+
+const formatDateTime = (value: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(value));
+
+type ActivitySortField = 'timestamp' | 'user' | 'activityType' | 'module' | 'status';
+
+type SelectChangeEvent = ChangeEvent<HTMLSelectElement>;
+
+const ActivityPage = () => {
+  const navigate = useNavigate();
+  const { permissions } = useAppSelector((state) => state.auth);
+  const grantedPermissions = permissions as PermissionKey[];
+  const { notify } = useToast();
+  const canExport = hasAnyPermission(grantedPermissions, ['ACTIVITY_EXPORT']);
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_OPTIONS[0]);
+  const [sort, setSort] = useState<{ field: ActivitySortField; direction: 'asc' | 'desc' }>({
+    field: 'timestamp',
+    direction: 'desc'
+  });
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
+  const [userFilter, setUserFilter] = useState('');
+  const [roleFilter, setRoleFilter] = useState<string[]>([]);
+  const [departmentFilter, setDepartmentFilter] = useState<string[]>([]);
+  const [moduleFilter, setModuleFilter] = useState<string[]>([]);
+  const [typeFilter, setTypeFilter] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  const [ipFilter, setIpFilter] = useState('');
+  const [deviceFilter, setDeviceFilter] = useState<string[]>([]);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [isExporting, setIsExporting] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearch(searchDraft.trim());
+      setPage(0);
+    }, 300);
+
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  const filtersKey = useMemo(
+    () => ({
+      user: userFilter.trim(),
+      roles: [...roleFilter].sort(),
+      departments: [...departmentFilter].sort(),
+      modules: [...moduleFilter].sort(),
+      types: [...typeFilter].sort(),
+      statuses: [...statusFilter].sort(),
+      ip: ipFilter.trim(),
+      devices: [...deviceFilter].sort(),
+      startDate,
+      endDate,
+      search
+    }),
+    [
+      userFilter,
+      roleFilter,
+      departmentFilter,
+      moduleFilter,
+      typeFilter,
+      statusFilter,
+      ipFilter,
+      deviceFilter,
+      startDate,
+      endDate,
+      search
+    ]
+  );
+
+  const buildQueryParams = (overrides?: { page?: number; size?: number }) => {
+    const params = new URLSearchParams();
+    const nextPage = overrides?.page ?? page;
+    const nextSize = overrides?.size ?? pageSize;
+    params.set('page', String(nextPage));
+    params.set('size', String(nextSize));
+    params.set('sort', sort.field);
+    params.set('direction', sort.direction);
+    if (search) {
+      params.set('search', search);
+    }
+    const trimmedUser = userFilter.trim();
+    if (trimmedUser) {
+      params.set('user', trimmedUser);
+    }
+    roleFilter.forEach((value) => params.append('role', value));
+    departmentFilter.forEach((value) => params.append('department', value));
+    moduleFilter.forEach((value) => params.append('module', value));
+    typeFilter.forEach((value) => params.append('type', value));
+    statusFilter.forEach((value) => params.append('status', value));
+    const trimmedIp = ipFilter.trim();
+    if (trimmedIp) {
+      params.set('ipAddress', trimmedIp);
+    }
+    deviceFilter.forEach((value) => params.append('device', value));
+    if (startDate) {
+      const startIso = new Date(`${startDate}T00:00:00`).toISOString();
+      params.set('startDate', startIso);
+    }
+    if (endDate) {
+      const endIso = new Date(`${endDate}T23:59:59.999`).toISOString();
+      params.set('endDate', endIso);
+    }
+    return params;
+  };
+
+  const filtersQuery = useQuery<ActivityFilterOptions>({
+    queryKey: ['activity', 'filters'],
+    queryFn: async () => {
+      const { data } = await api.get<ActivityFilterOptions>('/activity/filters');
+      return data;
+    }
+  });
+
+  const activityQuery = useQuery<Pagination<ActivityLogEntry>>({
+    queryKey: ['activity', 'list', { page, pageSize, sort, filtersKey }],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<ActivityLogEntry>>('/activity', {
+        params: buildQueryParams()
+      });
+      return data;
+    }
+  });
+
+  const activityData = activityQuery.data as Pagination<ActivityLogEntry> | undefined;
+  const activities: ActivityLogEntry[] = activityData?.content ?? [];
+  const totalElements = activityData?.totalElements ?? 0;
+  const totalPages = activityData?.totalPages ?? 0;
+  const isLoading = activityQuery.isLoading;
+  const hasError = activityQuery.isError;
+  const errorMessage = hasError
+    ? extractErrorMessage(activityQuery.error, 'Unable to load activity log records.')
+    : null;
+
+  useEffect(() => {
+    if (!isLoading && !hasError && totalPages > 0 && page >= totalPages) {
+      setPage(totalPages - 1);
+    }
+  }, [isLoading, hasError, totalPages, page]);
+
+  const handleSort = (field: ActivitySortField) => {
+    setSort((prev) => {
+      if (prev.field === field) {
+        const nextDirection = prev.direction === 'asc' ? 'desc' : 'asc';
+        return { field, direction: nextDirection };
+      }
+      return { field, direction: field === 'timestamp' ? 'desc' : 'asc' };
+    });
+    setPage(0);
+  };
+
+  const handlePageSizeChange = (event: SelectChangeEvent) => {
+    const nextSize = Number(event.target.value);
+    setPageSize(nextSize);
+    setPage(0);
+  };
+
+  const handlePreviousPage = () => {
+    setPage((prev) => Math.max(prev - 1, 0));
+  };
+
+  const handleNextPage = () => {
+    if (page + 1 < totalPages) {
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  const handleMultiSelectChange = (event: SelectChangeEvent, setter: (values: string[]) => void) => {
+    const values = Array.from(event.target.selectedOptions).map((option) => option.value);
+    setter(values);
+    setPage(0);
+  };
+
+  const handleClearFilters = () => {
+    setUserFilter('');
+    setRoleFilter([]);
+    setDepartmentFilter([]);
+    setModuleFilter([]);
+    setTypeFilter([]);
+    setStatusFilter([]);
+    setIpFilter('');
+    setDeviceFilter([]);
+    setStartDate('');
+    setEndDate('');
+    setSearch('');
+    setSearchDraft('');
+    setPage(0);
+  };
+
+  const handleExport = async (format: ExportFormat) => {
+    if (!canExport || isExporting) {
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const params = buildQueryParams({ page: 0, size: Math.max(pageSize, 1000) });
+      params.set('size', '1000');
+      const { data } = await api.get<Pagination<ActivityLogEntry>>('/activity', { params });
+      if (!data.content.length) {
+        notify({ type: 'error', message: 'There are no activity records to export for the selected filters.' });
+        return;
+      }
+
+      const rows = data.content.map((activity) => ({
+        timestamp: formatDateTime(activity.occurredAt),
+        user: activity.userName,
+        role: activity.userRole ?? '—',
+        department: activity.department ?? '—',
+        module: activity.module ?? '—',
+        type: activity.activityType,
+        status: activity.status ?? '—',
+        ipAddress: activity.ipAddress ?? '—',
+        device: activity.device ?? '—',
+        description: activity.description ?? '—'
+      }));
+
+      const columns = [
+        { key: 'timestamp', header: 'Timestamp' },
+        { key: 'user', header: 'User' },
+        { key: 'role', header: 'Role' },
+        { key: 'department', header: 'Department' },
+        { key: 'module', header: 'Module' },
+        { key: 'type', header: 'Activity Type' },
+        { key: 'status', header: 'Status' },
+        { key: 'ipAddress', header: 'IP Address' },
+        { key: 'device', header: 'Device' },
+        { key: 'description', header: 'Description' }
+      ];
+
+      exportDataset({
+        format,
+        columns,
+        rows,
+        fileName: 'activity-log',
+        title: 'Activity Log Export'
+      });
+    } catch (error) {
+      notify({ type: 'error', message: 'Unable to export activity records. Please try again.' });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const renderStatusBadge = (status?: string | null) => {
+    if (!status) {
+      return <span className="text-slate-400">—</span>;
+    }
+    const normalized = status.toUpperCase();
+    const isSuccess = normalized === 'SUCCESS';
+    const isFailure = normalized === 'FAILURE' || normalized === 'ERROR';
+    const badgeClass = isSuccess
+      ? 'bg-emerald-100 text-emerald-700'
+      : isFailure
+      ? 'bg-rose-100 text-rose-700'
+      : 'bg-slate-100 text-slate-700';
+    return <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${badgeClass}`}>{normalized}</span>;
+  };
+
+  const from = totalElements === 0 ? 0 : page * pageSize + 1;
+  const to = Math.min((page + 1) * pageSize, totalElements);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800">Activity</h1>
+          <p className="text-sm text-slate-500">
+            Review a complete audit trail of user actions across the platform.
+          </p>
+        </div>
+        {canExport && (
+          <ExportMenu onSelect={handleExport} isBusy={isExporting} disabled={isLoading} />
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="grid gap-4 lg:grid-cols-4">
+          <div className="lg:col-span-2">
+            <label className="block text-sm font-medium text-slate-600">Search</label>
+            <input
+              type="search"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+              placeholder="Search descriptions, modules, users, or IP addresses"
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">User</label>
+            <input
+              type="text"
+              value={userFilter}
+              onChange={(event) => {
+                setUserFilter(event.target.value);
+                setPage(0);
+              }}
+              placeholder="Name or ID"
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">IP Address</label>
+            <input
+              type="text"
+              value={ipFilter}
+              onChange={(event) => {
+                setIpFilter(event.target.value);
+                setPage(0);
+              }}
+              placeholder="e.g. 192.168.1.10"
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Roles</label>
+            <select
+              multiple
+              value={roleFilter}
+              onChange={(event) => handleMultiSelectChange(event, setRoleFilter)}
+              className="mt-1 h-28 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {filtersQuery.data?.roles.map((role) => (
+                <option key={role} value={role}>
+                  {role}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Departments</label>
+            <select
+              multiple
+              value={departmentFilter}
+              onChange={(event) => handleMultiSelectChange(event, setDepartmentFilter)}
+              className="mt-1 h-28 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {filtersQuery.data?.departments.map((department) => (
+                <option key={department} value={department}>
+                  {department}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Modules</label>
+            <select
+              multiple
+              value={moduleFilter}
+              onChange={(event) => handleMultiSelectChange(event, setModuleFilter)}
+              className="mt-1 h-28 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {filtersQuery.data?.modules.map((module) => (
+                <option key={module} value={module}>
+                  {module}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Activity Types</label>
+            <select
+              multiple
+              value={typeFilter}
+              onChange={(event) => handleMultiSelectChange(event, setTypeFilter)}
+              className="mt-1 h-28 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {filtersQuery.data?.activityTypes.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-4 lg:grid-cols-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Statuses</label>
+            <select
+              multiple
+              value={statusFilter}
+              onChange={(event) => handleMultiSelectChange(event, setStatusFilter)}
+              className="mt-1 h-28 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {filtersQuery.data?.statuses.map((status) => (
+                <option key={status} value={status}>
+                  {status}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Devices</label>
+            <select
+              multiple
+              value={deviceFilter}
+              onChange={(event) => handleMultiSelectChange(event, setDeviceFilter)}
+              className="mt-1 h-28 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              {filtersQuery.data?.devices.map((device) => (
+                <option key={device} value={device}>
+                  {device}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Start Date</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(event) => {
+                setStartDate(event.target.value);
+                setPage(0);
+              }}
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">End Date</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(event) => {
+                setEndDate(event.target.value);
+                setPage(0);
+              }}
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-slate-500">
+            Filters update results in real time. Use the multi-select fields to focus on specific actors or modules.
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleClearFilters}
+              className="inline-flex items-center rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+            >
+              Clear filters
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <DataTable
+        title="Activity log"
+        actions={
+          <div className="flex items-center gap-3">
+            <label className="text-sm text-slate-500">
+              Rows per page
+              <select
+                value={pageSize}
+                onChange={handlePageSizeChange}
+                className="ml-2 rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              >
+                {PAGE_SIZE_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        }
+      >
+        <thead className="bg-slate-50">
+          <tr>
+            <SortableColumnHeader
+              label="Timestamp"
+              field="timestamp"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <SortableColumnHeader
+              label="User"
+              field="user"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Role / Department</th>
+            <SortableColumnHeader
+              label="Module"
+              field="module"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <SortableColumnHeader
+              label="Activity Type"
+              field="activityType"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <SortableColumnHeader
+              label="Status"
+              field="status"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+              align="center"
+            />
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">IP Address</th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Device</th>
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Description</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 bg-white">
+          {isLoading && (
+            <tr>
+              <td colSpan={9} className="px-6 py-6 text-center text-sm text-slate-500">
+                Loading activity records…
+              </td>
+            </tr>
+          )}
+          {!isLoading && hasError && (
+            <tr>
+              <td colSpan={9} className="px-6 py-6 text-center text-sm text-rose-500">
+                {errorMessage}
+              </td>
+            </tr>
+          )}
+          {!isLoading && !hasError && activities.length === 0 && (
+            <tr>
+              <td colSpan={9} className="px-6 py-6 text-center text-sm text-slate-500">
+                No activity records found for the selected filters.
+              </td>
+            </tr>
+          )}
+          {!isLoading && !hasError &&
+            activities.map((activity) => (
+              <tr
+                key={activity.id}
+                onClick={() => navigate(`/activity/${activity.id}`)}
+                className="cursor-pointer transition hover:bg-slate-50"
+              >
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">
+                  {formatDateTime(activity.occurredAt)}
+                </td>
+                <td className="px-4 py-3 text-sm font-medium text-slate-800">{activity.userName}</td>
+                <td className="px-4 py-3 text-xs text-slate-500">
+                  <div className="font-medium text-slate-700">{activity.userRole ?? '—'}</div>
+                  <div>{activity.department ?? '—'}</div>
+                </td>
+                <td className="px-4 py-3 text-sm text-slate-600">{activity.module ?? '—'}</td>
+                <td className="px-4 py-3 text-sm text-slate-600">{activity.activityType}</td>
+                <td className="px-4 py-3 text-center">{renderStatusBadge(activity.status)}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-600">{activity.ipAddress ?? '—'}</td>
+                <td className="px-4 py-3 text-sm text-slate-600">{activity.device ?? '—'}</td>
+                <td className="px-4 py-3 text-sm text-slate-600">
+                  <div className="max-w-xs truncate" title={activity.description ?? undefined}>
+                    {activity.description ?? '—'}
+                  </div>
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </DataTable>
+
+      <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white px-6 py-4 text-sm shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-slate-600">
+          Showing <span className="font-semibold text-slate-800">{from}</span> to{' '}
+          <span className="font-semibold text-slate-800">{to}</span> of{' '}
+          <span className="font-semibold text-slate-800">{totalElements}</span> activity records
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handlePreviousPage}
+            disabled={page === 0}
+            className="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Previous
+          </button>
+          <span className="text-slate-500">
+            Page <span className="font-semibold text-slate-700">{page + 1}</span> of{' '}
+            <span className="font-semibold text-slate-700">{Math.max(totalPages, 1)}</span>
+          </span>
+          <button
+            type="button"
+            onClick={handleNextPage}
+            disabled={page + 1 >= totalPages}
+            className="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ActivityPage;

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -69,3 +69,33 @@ export interface Invoice {
   total: number;
   items: InvoiceItem[];
 }
+
+export interface ActivityLogEntry {
+  id: number;
+  occurredAt: string;
+  userId?: number | null;
+  userName: string;
+  userRole?: string | null;
+  department?: string | null;
+  module?: string | null;
+  activityType: string;
+  description?: string | null;
+  status?: string | null;
+  ipAddress?: string | null;
+  device?: string | null;
+}
+
+export interface ActivityLogDetail extends ActivityLogEntry {
+  context?: Record<string, unknown> | null;
+  rawContext?: string | null;
+}
+
+export interface ActivityFilterOptions {
+  activityTypes: string[];
+  modules: string[];
+  statuses: string[];
+  roles: string[];
+  departments: string[];
+  ipAddresses: string[];
+  devices: string[];
+}

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -50,5 +50,6 @@ export const TAB_RULES: Record<string, PermissionKey[]> = {
     'INVOICE_UPDATE',
     'INVOICE_DELETE'
   ],
+  Activity: ['ACTIVITY_VIEW'],
   Settings: ['SETTINGS_VIEW']
 };


### PR DESCRIPTION
## Summary
- add a dedicated activity log domain including entity, repository, service, controller, and database migration with seed data and permissions
- expose REST endpoints for listing, filtering, exporting, and inspecting detailed activity entries
- introduce activity log list/detail pages, navigation, and export tooling in the frontend

## Testing
- npm --prefix frontend run build
- mvn -f backend/pom.xml test *(fails: unable to download dependencies from Maven Central, returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dbc4cd2c8323b3b1ec8d98907f73