### PR TITLE
Add profile management fields and session restoration

### DIFF
--- a/backend/src/main/java/com/example/rbac/activity/controller/ActivityController.java
+++ b/backend/src/main/java/com/example/rbac/activity/controller/ActivityController.java
@@ -1,0 +1,74 @@
+package com.example.rbac.activity.controller;
+
+import com.example.rbac.activity.dto.ActivityFilterOptionsDto;
+import com.example.rbac.activity.dto.ActivityLogDetailDto;
+import com.example.rbac.activity.dto.ActivityLogDto;
+import com.example.rbac.activity.dto.ActivityLogFilter;
+import com.example.rbac.activity.service.ActivityLogService;
+import com.example.rbac.common.pagination.PageResponse;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/activity")
+public class ActivityController {
+
+    private final ActivityLogService activityLogService;
+
+    public ActivityController(ActivityLogService activityLogService) {
+        this.activityLogService = activityLogService;
+    }
+
+    @GetMapping
+    public PageResponse<ActivityLogDto> search(@RequestParam(name = "page", defaultValue = "0") int page,
+                                               @RequestParam(name = "size", defaultValue = "25") int size,
+                                               @RequestParam(name = "sort", defaultValue = "timestamp") String sort,
+                                               @RequestParam(name = "direction", defaultValue = "desc") String direction,
+                                               @RequestParam(name = "search", required = false) String search,
+                                               @RequestParam(name = "user", required = false) String user,
+                                               @RequestParam(name = "role", required = false) List<String> roles,
+                                               @RequestParam(name = "department", required = false) List<String> departments,
+                                               @RequestParam(name = "module", required = false) List<String> modules,
+                                               @RequestParam(name = "type", required = false) List<String> types,
+                                               @RequestParam(name = "status", required = false) List<String> statuses,
+                                               @RequestParam(name = "ipAddress", required = false) List<String> ipAddresses,
+                                               @RequestParam(name = "device", required = false) List<String> devices,
+                                               @RequestParam(name = "startDate", required = false)
+                                               @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                               OffsetDateTime startDate,
+                                               @RequestParam(name = "endDate", required = false)
+                                               @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                               OffsetDateTime endDate) {
+        ActivityLogFilter filter = new ActivityLogFilter(
+                search,
+                user,
+                roles,
+                departments,
+                modules,
+                types,
+                statuses,
+                ipAddresses,
+                devices,
+                startDate != null ? startDate.toInstant() : null,
+                endDate != null ? endDate.toInstant() : null
+        );
+        return activityLogService.search(page, size, sort, direction, filter);
+    }
+
+    @GetMapping("/{id}")
+    public ActivityLogDetailDto getDetail(@PathVariable("id") Long id) {
+        return activityLogService.getDetail(id);
+    }
+
+    @GetMapping("/filters")
+    public ActivityFilterOptionsDto getFilters() {
+        return activityLogService.getFilterOptions();
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityFilterOptionsDto.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityFilterOptionsDto.java
@@ -1,0 +1,14 @@
+package com.example.rbac.activity.dto;
+
+import java.util.List;
+
+public record ActivityFilterOptionsDto(
+        List<String> activityTypes,
+        List<String> modules,
+        List<String> statuses,
+        List<String> roles,
+        List<String> departments,
+        List<String> ipAddresses,
+        List<String> devices
+) {
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDetailDto.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDetailDto.java
@@ -1,0 +1,22 @@
+package com.example.rbac.activity.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ActivityLogDetailDto(
+        Long id,
+        Instant occurredAt,
+        Long userId,
+        String userName,
+        String userRole,
+        String department,
+        String module,
+        String activityType,
+        String description,
+        String status,
+        String ipAddress,
+        String device,
+        Map<String, Object> context,
+        String rawContext
+) {
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDto.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogDto.java
@@ -1,0 +1,19 @@
+package com.example.rbac.activity.dto;
+
+import java.time.Instant;
+
+public record ActivityLogDto(
+        Long id,
+        Instant occurredAt,
+        Long userId,
+        String userName,
+        String userRole,
+        String department,
+        String module,
+        String activityType,
+        String description,
+        String status,
+        String ipAddress,
+        String device
+) {
+}

--- a/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogFilter.java
+++ b/backend/src/main/java/com/example/rbac/activity/dto/ActivityLogFilter.java
@@ -1,0 +1,49 @@
+package com.example.rbac.activity.dto;
+
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record ActivityLogFilter(
+        String search,
+        String user,
+        List<String> roles,
+        List<String> departments,
+        List<String> modules,
+        List<String> activityTypes,
+        List<String> statuses,
+        List<String> ipAddresses,
+        List<String> devices,
+        Instant startDate,
+        Instant endDate
+) {
+    public ActivityLogFilter {
+        search = normalizeText(search);
+        user = normalizeText(user);
+        roles = normalizeList(roles);
+        departments = normalizeList(departments);
+        modules = normalizeList(modules);
+        activityTypes = normalizeList(activityTypes);
+        statuses = normalizeList(statuses);
+        ipAddresses = normalizeList(ipAddresses);
+        devices = normalizeList(devices);
+    }
+
+    private static String normalizeText(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private static List<String> normalizeList(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return values.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.collectingAndThen(Collectors.toList(), List::copyOf));
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/mapper/ActivityLogMapper.java
+++ b/backend/src/main/java/com/example/rbac/activity/mapper/ActivityLogMapper.java
@@ -1,0 +1,73 @@
+package com.example.rbac.activity.mapper;
+
+import com.example.rbac.activity.dto.ActivityLogDetailDto;
+import com.example.rbac.activity.dto.ActivityLogDto;
+import com.example.rbac.activity.model.ActivityLog;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class ActivityLogMapper {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final ObjectMapper objectMapper;
+
+    public ActivityLogMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public ActivityLogDto toDto(ActivityLog log) {
+        if (log == null) {
+            return null;
+        }
+        return new ActivityLogDto(
+                log.getId(),
+                log.getOccurredAt(),
+                log.getUserId(),
+                log.getUserName(),
+                log.getUserRole(),
+                log.getDepartment(),
+                log.getModuleName(),
+                log.getActivityType(),
+                log.getDescription(),
+                log.getStatus(),
+                log.getIpAddress(),
+                log.getDevice()
+        );
+    }
+
+    public ActivityLogDetailDto toDetail(ActivityLog log) {
+        if (log == null) {
+            return null;
+        }
+        Map<String, Object> context = null;
+        if (log.getContext() != null) {
+            try {
+                context = objectMapper.readValue(log.getContext(), MAP_TYPE);
+            } catch (JsonProcessingException ignored) {
+                context = null;
+            }
+        }
+        return new ActivityLogDetailDto(
+                log.getId(),
+                log.getOccurredAt(),
+                log.getUserId(),
+                log.getUserName(),
+                log.getUserRole(),
+                log.getDepartment(),
+                log.getModuleName(),
+                log.getActivityType(),
+                log.getDescription(),
+                log.getStatus(),
+                log.getIpAddress(),
+                log.getDevice(),
+                context,
+                log.getContext()
+        );
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/model/ActivityLog.java
+++ b/backend/src/main/java/com/example/rbac/activity/model/ActivityLog.java
@@ -1,0 +1,161 @@
+package com.example.rbac.activity.model;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "activity_logs")
+public class ActivityLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "user_name", nullable = false, length = 150)
+    private String userName;
+
+    @Column(name = "user_role", length = 150)
+    private String userRole;
+
+    @Column(length = 150)
+    private String department;
+
+    @Column(name = "module_name", length = 150)
+    private String moduleName;
+
+    @Column(name = "activity_type", nullable = false, length = 100)
+    private String activityType;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(length = 50)
+    private String status;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(length = 150)
+    private String device;
+
+    @Column(name = "context", columnDefinition = "TEXT")
+    private String context;
+
+    @PrePersist
+    public void prePersist() {
+        if (occurredAt == null) {
+            occurredAt = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+
+    public void setOccurredAt(Instant occurredAt) {
+        this.occurredAt = occurredAt;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(String userRole) {
+        this.userRole = userRole;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public String getActivityType() {
+        return activityType;
+    }
+
+    public void setActivityType(String activityType) {
+        this.activityType = activityType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getDevice() {
+        return device;
+    }
+
+    public void setDevice(String device) {
+        this.device = device;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/repository/ActivityLogRepository.java
+++ b/backend/src/main/java/com/example/rbac/activity/repository/ActivityLogRepository.java
@@ -1,0 +1,34 @@
+package com.example.rbac.activity.repository;
+
+import com.example.rbac.activity.model.ActivityLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long>, JpaSpecificationExecutor<ActivityLog> {
+
+    @Query("select distinct a.activityType from ActivityLog a where a.activityType is not null order by lower(a.activityType)")
+    List<String> findDistinctActivityTypes();
+
+    @Query("select distinct a.moduleName from ActivityLog a where a.moduleName is not null order by lower(a.moduleName)")
+    List<String> findDistinctModules();
+
+    @Query("select distinct a.status from ActivityLog a where a.status is not null order by lower(a.status)")
+    List<String> findDistinctStatuses();
+
+    @Query("select distinct a.userRole from ActivityLog a where a.userRole is not null order by lower(a.userRole)")
+    List<String> findDistinctRoles();
+
+    @Query("select distinct a.department from ActivityLog a where a.department is not null order by lower(a.department)")
+    List<String> findDistinctDepartments();
+
+    @Query("select distinct a.ipAddress from ActivityLog a where a.ipAddress is not null order by a.ipAddress")
+    List<String> findDistinctIpAddresses();
+
+    @Query("select distinct a.device from ActivityLog a where a.device is not null order by lower(a.device)")
+    List<String> findDistinctDevices();
+}

--- a/backend/src/main/java/com/example/rbac/activity/service/ActivityLogService.java
+++ b/backend/src/main/java/com/example/rbac/activity/service/ActivityLogService.java
@@ -1,0 +1,120 @@
+package com.example.rbac.activity.service;
+
+import com.example.rbac.activity.dto.ActivityFilterOptionsDto;
+import com.example.rbac.activity.dto.ActivityLogDetailDto;
+import com.example.rbac.activity.dto.ActivityLogDto;
+import com.example.rbac.activity.dto.ActivityLogFilter;
+import com.example.rbac.activity.mapper.ActivityLogMapper;
+import com.example.rbac.activity.model.ActivityLog;
+import com.example.rbac.activity.repository.ActivityLogRepository;
+import com.example.rbac.activity.spec.ActivityLogSpecifications;
+import com.example.rbac.common.exception.ApiException;
+import com.example.rbac.common.pagination.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class ActivityLogService {
+
+    private static final Map<String, String> SORT_MAPPING;
+
+    static {
+        SORT_MAPPING = new HashMap<>();
+        SORT_MAPPING.put("timestamp", "occurredAt");
+        SORT_MAPPING.put("user", "userName");
+        SORT_MAPPING.put("activityType", "activityType");
+        SORT_MAPPING.put("module", "moduleName");
+        SORT_MAPPING.put("status", "status");
+    }
+
+    private final ActivityLogRepository activityLogRepository;
+    private final ActivityLogMapper activityLogMapper;
+
+    public ActivityLogService(ActivityLogRepository activityLogRepository,
+                              ActivityLogMapper activityLogMapper) {
+        this.activityLogRepository = activityLogRepository;
+        this.activityLogMapper = activityLogMapper;
+    }
+
+    @PreAuthorize("hasAuthority('ACTIVITY_VIEW')")
+    @Transactional(readOnly = true)
+    public PageResponse<ActivityLogDto> search(int page,
+                                               int size,
+                                               String sort,
+                                               String direction,
+                                               ActivityLogFilter filter) {
+        Pageable pageable = buildPageable(page, size, sort, direction);
+        Specification<ActivityLog> specification = buildSpecification(filter);
+        Page<ActivityLogDto> result = activityLogRepository.findAll(specification, pageable)
+                .map(activityLogMapper::toDto);
+        return PageResponse.from(result);
+    }
+
+    @PreAuthorize("hasAuthority('ACTIVITY_VIEW')")
+    @Transactional(readOnly = true)
+    public ActivityLogDetailDto getDetail(Long id) {
+        ActivityLog log = activityLogRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Activity not found"));
+        return activityLogMapper.toDetail(log);
+    }
+
+    @PreAuthorize("hasAuthority('ACTIVITY_VIEW')")
+    @Transactional(readOnly = true)
+    public ActivityFilterOptionsDto getFilterOptions() {
+        return new ActivityFilterOptionsDto(
+                activityLogRepository.findDistinctActivityTypes(),
+                activityLogRepository.findDistinctModules(),
+                activityLogRepository.findDistinctStatuses(),
+                activityLogRepository.findDistinctRoles(),
+                activityLogRepository.findDistinctDepartments(),
+                activityLogRepository.findDistinctIpAddresses(),
+                activityLogRepository.findDistinctDevices()
+        );
+    }
+
+    private Pageable buildPageable(int page, int size, String sort, String direction) {
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.min(Math.max(size, 1), 200);
+        String normalizedSort = sort == null ? "timestamp" : sort.toLowerCase();
+        String property = SORT_MAPPING.getOrDefault(normalizedSort, SORT_MAPPING.get("timestamp"));
+        Sort.Direction sortDirection = "asc".equalsIgnoreCase(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        return PageRequest.of(safePage, safeSize, Sort.by(sortDirection, property));
+    }
+
+    private Specification<ActivityLog> buildSpecification(ActivityLogFilter filter) {
+        Specification<ActivityLog> spec = Specification.where(null);
+        spec = combine(spec, ActivityLogSpecifications.searchTerm(filter.search()));
+        spec = combine(spec, ActivityLogSpecifications.userQuery(filter.user()));
+        spec = combine(spec, ActivityLogSpecifications.roles(filter.roles()));
+        spec = combine(spec, ActivityLogSpecifications.departments(filter.departments()));
+        spec = combine(spec, ActivityLogSpecifications.modules(filter.modules()));
+        spec = combine(spec, ActivityLogSpecifications.activityTypes(filter.activityTypes()));
+        spec = combine(spec, ActivityLogSpecifications.statuses(filter.statuses()));
+        spec = combine(spec, ActivityLogSpecifications.ipAddresses(filter.ipAddresses()));
+        spec = combine(spec, ActivityLogSpecifications.devices(filter.devices()));
+        spec = combine(spec, ActivityLogSpecifications.occurredAfter(filter.startDate()));
+        spec = combine(spec, ActivityLogSpecifications.occurredBefore(filter.endDate()));
+        return spec;
+    }
+
+    private Specification<ActivityLog> combine(Specification<ActivityLog> base,
+                                               Specification<ActivityLog> addition) {
+        if (base == null) {
+            return addition;
+        }
+        if (addition == null) {
+            return base;
+        }
+        return base.and(addition);
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/service/ActivityRecorder.java
+++ b/backend/src/main/java/com/example/rbac/activity/service/ActivityRecorder.java
@@ -1,0 +1,289 @@
+package com.example.rbac.activity.service;
+
+import com.example.rbac.activity.model.ActivityLog;
+import com.example.rbac.activity.repository.ActivityLogRepository;
+import com.example.rbac.users.model.User;
+import com.example.rbac.users.model.UserPrincipal;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class ActivityRecorder {
+
+    private static final Logger log = LoggerFactory.getLogger(ActivityRecorder.class);
+
+    private final ActivityLogRepository activityLogRepository;
+    private final ObjectMapper objectMapper;
+
+    public ActivityRecorder(ActivityLogRepository activityLogRepository, ObjectMapper objectMapper) {
+        this.activityLogRepository = activityLogRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    public void record(String module, String activityType, String description) {
+        record(module, activityType, description, null, null);
+    }
+
+    public void record(String module, String activityType, String description, String status, Map<String, ?> context) {
+        recordInternal(module, activityType, description, status, context, resolveCurrentUser());
+    }
+
+    public void recordForUser(User user, String module, String activityType, String description, String status, Map<String, ?> context) {
+        recordInternal(module, activityType, description, status, context, Optional.ofNullable(user));
+    }
+
+    @Transactional
+    protected void recordInternal(String module,
+                                  String activityType,
+                                  String description,
+                                  String status,
+                                  Map<String, ?> context,
+                                  Optional<User> userOverride) {
+        try {
+            ActivityLog logEntry = new ActivityLog();
+            logEntry.setModuleName(normalize(module, "General"));
+            logEntry.setActivityType(normalize(activityType, "UNKNOWN").toUpperCase(Locale.ROOT));
+            logEntry.setDescription(normalize(description, ""));
+            logEntry.setStatus(normalize(status, "SUCCESS").toUpperCase(Locale.ROOT));
+            if (context != null && !context.isEmpty()) {
+                logEntry.setContext(serializeContext(context));
+            }
+
+            userOverride.or(this::resolveCurrentUser)
+                    .ifPresentOrElse(user -> applyUserInfo(logEntry, user),
+                            () -> applySystemUser(logEntry));
+
+            applyRequestInfo(logEntry);
+
+            activityLogRepository.save(logEntry);
+        } catch (Exception ex) {
+            log.warn("Failed to record activity log for module '{}' and activity '{}'", module, activityType, ex);
+        }
+    }
+
+    private Optional<User> resolveCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserPrincipal userPrincipal) {
+            return Optional.ofNullable(userPrincipal.getUser());
+        }
+        if (principal instanceof User user) {
+            return Optional.of(user);
+        }
+        return Optional.empty();
+    }
+
+    private void applyUserInfo(ActivityLog logEntry, User user) {
+        logEntry.setUserId(user.getId());
+        logEntry.setUserName(normalize(user.getFullName(), user.getEmail()));
+        logEntry.setUserRole(resolveRoles(user.getRoles().stream()
+                .map(role -> normalize(role.getName(), role.getKey()))
+                .collect(Collectors.toSet())));
+        logEntry.setDepartment(null);
+    }
+
+    private void applySystemUser(ActivityLog logEntry) {
+        logEntry.setUserId(null);
+        logEntry.setUserName("System");
+        logEntry.setUserRole(null);
+        logEntry.setDepartment(null);
+    }
+
+    private void applyRequestInfo(ActivityLog logEntry) {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (!(attributes instanceof ServletRequestAttributes servletAttributes)) {
+            return;
+        }
+        HttpServletRequest request = servletAttributes.getRequest();
+        if (request == null) {
+            return;
+        }
+
+        String ip = extractClientIp(request);
+        if (ip != null && !ip.isBlank()) {
+            logEntry.setIpAddress(ip);
+        }
+
+        String device = extractDeviceInfo(request.getHeader("User-Agent"));
+        if (device != null && !device.isBlank()) {
+            logEntry.setDevice(device);
+        }
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        String candidate = resolveFirstAddress(forwardedFor);
+        if (candidate != null) {
+            return candidate;
+        }
+        String realIp = request.getHeader("X-Real-IP");
+        candidate = resolveFirstAddress(realIp);
+        if (candidate != null) {
+            return candidate;
+        }
+        return normalizeIp(request.getRemoteAddr());
+    }
+
+    private String resolveFirstAddress(String headerValue) {
+        if (headerValue == null || headerValue.isBlank()) {
+            return null;
+        }
+        String[] segments = headerValue.split(",");
+        for (String segment : segments) {
+            String candidate = segment.trim();
+            if (!candidate.isEmpty() && !"unknown".equalsIgnoreCase(candidate)) {
+                return normalizeIp(candidate);
+            }
+        }
+        return null;
+    }
+
+    private String normalizeIp(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return null;
+        }
+        String cleaned = ip.trim();
+        if (cleaned.startsWith("::ffff:")) {
+            cleaned = cleaned.substring(7);
+        }
+        if ("::1".equals(cleaned) || "0:0:0:0:0:0:0:1".equals(cleaned)) {
+            cleaned = "127.0.0.1";
+        }
+        if (cleaned.contains(".") && cleaned.contains(":") && !cleaned.contains("::")) {
+            cleaned = cleaned.substring(0, cleaned.indexOf(':'));
+        }
+        int scopeIndex = cleaned.indexOf('%');
+        if (scopeIndex > -1) {
+            cleaned = cleaned.substring(0, scopeIndex);
+        }
+        return cleaned.length() > 45 ? cleaned.substring(0, 45) : cleaned;
+    }
+
+    private String extractDeviceInfo(String userAgent) {
+        if (userAgent == null || userAgent.isBlank()) {
+            return null;
+        }
+        String browser = detectBrowser(userAgent);
+        String operatingSystem = detectOperatingSystem(userAgent);
+        StringBuilder builder = new StringBuilder();
+        if (browser != null) {
+            builder.append(browser);
+        }
+        if (operatingSystem != null) {
+            if (builder.length() > 0) {
+                builder.append(" on ");
+            }
+            builder.append(operatingSystem);
+        }
+        String description = builder.length() > 0 ? builder.toString() : userAgent.trim();
+        return description.length() > 150 ? description.substring(0, 150) : description;
+    }
+
+    private String detectBrowser(String userAgent) {
+        String normalized = userAgent.toLowerCase(Locale.ROOT);
+        if (normalized.contains("edg/")) {
+            return "Microsoft Edge";
+        }
+        if (normalized.contains("chrome/") && !normalized.contains("chromium") && !normalized.contains("edg/") && !normalized.contains("opr/")) {
+            return "Google Chrome";
+        }
+        if (normalized.contains("safari/") && normalized.contains("version/") && !normalized.contains("chrome/")) {
+            return "Safari";
+        }
+        if (normalized.contains("firefox/")) {
+            return "Mozilla Firefox";
+        }
+        if (normalized.contains("opr/") || normalized.contains("opera")) {
+            return "Opera";
+        }
+        if (normalized.contains("msie") || normalized.contains("trident/")) {
+            return "Internet Explorer";
+        }
+        return null;
+    }
+
+    private String detectOperatingSystem(String userAgent) {
+        String normalized = userAgent.toLowerCase(Locale.ROOT);
+        if (normalized.contains("iphone") || normalized.contains("ipad")) {
+            return "iOS";
+        }
+        if (normalized.contains("windows nt 10") || normalized.contains("windows nt 11")) {
+            return "Windows";
+        }
+        if (normalized.contains("mac os x") || normalized.contains("macintosh")) {
+            return "macOS";
+        }
+        if (normalized.contains("cros")) {
+            return "ChromeOS";
+        }
+        if (normalized.contains("android")) {
+            return "Android";
+        }
+        if (normalized.contains("linux")) {
+            return "Linux";
+        }
+        return null;
+    }
+
+    private String serializeContext(Map<String, ?> context) {
+        Map<String, ?> safeContext = sanitizeContext(context);
+        try {
+            return objectMapper.writeValueAsString(safeContext);
+        } catch (JsonProcessingException ex) {
+            log.debug("Failed to serialize activity context", ex);
+            return null;
+        }
+    }
+
+    private Map<String, ?> sanitizeContext(Map<String, ?> context) {
+        if (context == null || context.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> sanitized = new HashMap<>();
+        context.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            sanitized.put(key, value);
+        });
+        return sanitized;
+    }
+
+    private String normalize(String value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? defaultValue : trimmed;
+    }
+
+    private String resolveRoles(Set<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return null;
+        }
+        return roles.stream()
+                .filter(role -> role != null && !role.isBlank())
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/backend/src/main/java/com/example/rbac/activity/spec/ActivityLogSpecifications.java
+++ b/backend/src/main/java/com/example/rbac/activity/spec/ActivityLogSpecifications.java
@@ -1,0 +1,144 @@
+package com.example.rbac.activity.spec;
+
+import com.example.rbac.activity.model.ActivityLog;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class ActivityLogSpecifications {
+
+    private ActivityLogSpecifications() {
+    }
+
+    public static Specification<ActivityLog> searchTerm(String term) {
+        if (!StringUtils.hasText(term)) {
+            return null;
+        }
+        final String pattern = "%" + term.trim().toLowerCase() + "%";
+        return (root, query, builder) -> builder.or(
+                builder.like(builder.lower(root.get("description")), pattern),
+                builder.like(builder.lower(root.get("moduleName")), pattern),
+                builder.like(builder.lower(root.get("activityType")), pattern),
+                builder.like(builder.lower(root.get("userName")), pattern),
+                builder.like(builder.lower(root.get("ipAddress")), pattern),
+                builder.like(builder.lower(root.get("device")), pattern)
+        );
+    }
+
+    public static Specification<ActivityLog> userQuery(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        final String trimmed = value.trim();
+        final String pattern = "%" + trimmed.toLowerCase() + "%";
+        final boolean numeric = trimmed.chars().allMatch(Character::isDigit);
+        return (root, query, builder) -> {
+            if (numeric) {
+                Long userId;
+                try {
+                    userId = Long.parseLong(trimmed);
+                } catch (NumberFormatException ex) {
+                    userId = null;
+                }
+                if (userId != null) {
+                    return builder.or(
+                            builder.equal(root.get("userId"), userId),
+                            builder.like(builder.lower(root.get("userName")), pattern)
+                    );
+                }
+            }
+            return builder.like(builder.lower(root.get("userName")), pattern);
+        };
+    }
+
+    public static Specification<ActivityLog> roles(Collection<String> roles) {
+        List<String> normalized = normalizeUpperList(roles);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("userRole")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> departments(Collection<String> departments) {
+        List<String> normalized = normalizeUpperList(departments);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("department")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> modules(Collection<String> modules) {
+        List<String> normalized = normalizeUpperList(modules);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("moduleName")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> activityTypes(Collection<String> types) {
+        List<String> normalized = normalizeUpperList(types);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("activityType")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> statuses(Collection<String> statuses) {
+        List<String> normalized = normalizeUpperList(statuses);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("status")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> ipAddresses(Collection<String> ipAddresses) {
+        List<String> normalized = normalizeList(ipAddresses);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> root.get("ipAddress").in(normalized);
+    }
+
+    public static Specification<ActivityLog> devices(Collection<String> devices) {
+        List<String> normalized = normalizeUpperList(devices);
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> builder.upper(root.get("device")).in(normalized);
+    }
+
+    public static Specification<ActivityLog> occurredAfter(Instant start) {
+        if (start == null) {
+            return null;
+        }
+        return (root, query, builder) -> builder.greaterThanOrEqualTo(root.get("occurredAt"), start);
+    }
+
+    public static Specification<ActivityLog> occurredBefore(Instant end) {
+        if (end == null) {
+            return null;
+        }
+        return (root, query, builder) -> builder.lessThanOrEqualTo(root.get("occurredAt"), end);
+    }
+
+    private static List<String> normalizeUpperList(Collection<String> values) {
+        return normalizeList(values).stream()
+                .map(value -> value.toUpperCase())
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> normalizeList(Collection<String> values) {
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(StringUtils::hasText)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/example/rbac/auth/dto/SignupRequest.java
+++ b/backend/src/main/java/com/example/rbac/auth/dto/SignupRequest.java
@@ -15,7 +15,10 @@ public class SignupRequest {
     private String password;
 
     @NotBlank
-    private String fullName;
+    private String firstName;
+
+    @NotBlank
+    private String lastName;
 
     public String getEmail() {
         return email;
@@ -33,11 +36,19 @@ public class SignupRequest {
         this.password = password;
     }
 
-    public String getFullName() {
-        return fullName;
+    public String getFirstName() {
+        return firstName;
     }
 
-    public void setFullName(String fullName) {
-        this.fullName = fullName;
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
     }
 }

--- a/backend/src/main/java/com/example/rbac/auth/service/AuthService.java
+++ b/backend/src/main/java/com/example/rbac/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.rbac.auth.service;
 
+import com.example.rbac.activity.service.ActivityRecorder;
 import com.example.rbac.auth.dto.AuthResponse;
 import com.example.rbac.auth.dto.LoginRequest;
 import com.example.rbac.auth.dto.RefreshTokenRequest;
@@ -20,8 +21,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 public class AuthService {
@@ -33,6 +37,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final UserMapper userMapper;
     private final SettingsService settingsService;
+    private final ActivityRecorder activityRecorder;
 
     public AuthService(UserRepository userRepository,
                        RefreshTokenRepository refreshTokenRepository,
@@ -40,7 +45,8 @@ public class AuthService {
                        AuthenticationManager authenticationManager,
                        JwtService jwtService,
                        UserMapper userMapper,
-                       SettingsService settingsService) {
+                       SettingsService settingsService,
+                       ActivityRecorder activityRecorder) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.passwordEncoder = passwordEncoder;
@@ -48,21 +54,29 @@ public class AuthService {
         this.jwtService = jwtService;
         this.userMapper = userMapper;
         this.settingsService = settingsService;
+        this.activityRecorder = activityRecorder;
     }
 
     @Transactional
     public AuthResponse signup(SignupRequest request) {
-        userRepository.findByEmail(request.getEmail()).ifPresent(user -> {
+        String email = request.getEmail() == null ? "" : request.getEmail().trim();
+        userRepository.findByEmail(email).ifPresent(user -> {
             throw new ApiException(HttpStatus.BAD_REQUEST, "Email already in use");
         });
         User user = new User();
-        user.setEmail(request.getEmail());
-        user.setFullName(request.getFullName());
+        String firstName = request.getFirstName() == null ? "" : request.getFirstName().trim();
+        String lastName = request.getLastName() == null ? "" : request.getLastName().trim();
+        user.setEmail(email);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setFullName(buildFullName(firstName, lastName));
         user.setPasswordHash(passwordEncoder.encode(request.getPassword()));
         user = userRepository.save(user);
         user = userRepository.findDetailedById(user.getId()).orElseThrow();
         String refreshTokenValue = createRefreshToken(user);
-        return buildAuthResponse(user, refreshTokenValue);
+        AuthResponse response = buildAuthResponse(user, refreshTokenValue);
+        activityRecorder.recordForUser(user, "Authentication", "SIGNUP", "User registered", "SUCCESS", buildAuthContext(user));
+        return response;
     }
 
     @Transactional
@@ -75,7 +89,9 @@ public class AuthService {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new ApiException(HttpStatus.UNAUTHORIZED, "User not found"));
         String refreshTokenValue = createRefreshToken(user);
-        return buildAuthResponse(user, refreshTokenValue);
+        AuthResponse response = buildAuthResponse(user, refreshTokenValue);
+        activityRecorder.recordForUser(user, "Authentication", "LOGIN", "User logged in", "SUCCESS", buildAuthContext(user));
+        return response;
     }
 
     @Transactional
@@ -90,7 +106,9 @@ public class AuthService {
         User user = userRepository.findDetailedById(refreshToken.getUser().getId())
                 .orElseThrow(() -> new ApiException(HttpStatus.UNAUTHORIZED, "User not found"));
         String newRefresh = createRefreshToken(user);
-        return buildAuthResponse(user, newRefresh);
+        AuthResponse response = buildAuthResponse(user, newRefresh);
+        activityRecorder.recordForUser(user, "Authentication", "TOKEN_REFRESH", "Refreshed access token", "SUCCESS", buildAuthContext(user));
+        return response;
     }
 
     @Transactional
@@ -98,6 +116,7 @@ public class AuthService {
         refreshTokenRepository.findByToken(request.getRefreshToken()).ifPresent(token -> {
             token.setRevoked(true);
             refreshTokenRepository.save(token);
+            activityRecorder.recordForUser(token.getUser(), "Authentication", "LOGOUT", "User logged out", "SUCCESS", buildLogoutContext(token));
         });
     }
 
@@ -130,5 +149,45 @@ public class AuthService {
         response.setRevokedPermissions(userDto.getRevokedPermissions());
         response.setTheme(settingsService.getTheme());
         return response;
+    }
+
+    private Map<String, Object> buildAuthContext(User user) {
+        HashMap<String, Object> context = new HashMap<>();
+        if (user == null) {
+            return context;
+        }
+        if (user.getId() != null) {
+            context.put("userId", user.getId());
+        }
+        if (user.getEmail() != null) {
+            context.put("email", user.getEmail());
+        }
+        context.put("active", user.isActive());
+        return context;
+    }
+
+    private Map<String, Object> buildLogoutContext(RefreshToken token) {
+        HashMap<String, Object> context = new HashMap<>();
+        if (token.getId() != null) {
+            context.put("refreshTokenId", token.getId());
+        }
+        if (token.getUser() != null && token.getUser().getId() != null) {
+            context.put("userId", token.getUser().getId());
+        }
+        return context;
+    }
+
+    private String buildFullName(String firstName, String lastName) {
+        StringBuilder builder = new StringBuilder();
+        if (StringUtils.hasText(firstName)) {
+            builder.append(firstName.trim());
+        }
+        if (StringUtils.hasText(lastName)) {
+            if (builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append(lastName.trim());
+        }
+        return builder.length() > 0 ? builder.toString() : null;
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/dto/CreateUserRequest.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/CreateUserRequest.java
@@ -16,7 +16,10 @@ public class CreateUserRequest {
     private String password;
 
     @NotBlank
-    private String fullName;
+    private String firstName;
+
+    @NotBlank
+    private String lastName;
 
     private boolean active = true;
 
@@ -25,6 +28,18 @@ public class CreateUserRequest {
     private Set<String> permissionKeys;
 
     private Set<String> revokedPermissionKeys;
+
+    private String phoneNumber;
+
+    private String whatsappNumber;
+
+    private String facebookUrl;
+
+    private String linkedinUrl;
+
+    private String skypeId;
+
+    private String emailSignature;
 
     public String getEmail() {
         return email;
@@ -42,12 +57,20 @@ public class CreateUserRequest {
         this.password = password;
     }
 
-    public String getFullName() {
-        return fullName;
+    public String getFirstName() {
+        return firstName;
     }
 
-    public void setFullName(String fullName) {
-        this.fullName = fullName;
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
     }
 
     public boolean isActive() {
@@ -80,5 +103,53 @@ public class CreateUserRequest {
 
     public void setRevokedPermissionKeys(Set<String> revokedPermissionKeys) {
         this.revokedPermissionKeys = revokedPermissionKeys;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getWhatsappNumber() {
+        return whatsappNumber;
+    }
+
+    public void setWhatsappNumber(String whatsappNumber) {
+        this.whatsappNumber = whatsappNumber;
+    }
+
+    public String getFacebookUrl() {
+        return facebookUrl;
+    }
+
+    public void setFacebookUrl(String facebookUrl) {
+        this.facebookUrl = facebookUrl;
+    }
+
+    public String getLinkedinUrl() {
+        return linkedinUrl;
+    }
+
+    public void setLinkedinUrl(String linkedinUrl) {
+        this.linkedinUrl = linkedinUrl;
+    }
+
+    public String getSkypeId() {
+        return skypeId;
+    }
+
+    public void setSkypeId(String skypeId) {
+        this.skypeId = skypeId;
+    }
+
+    public String getEmailSignature() {
+        return emailSignature;
+    }
+
+    public void setEmailSignature(String emailSignature) {
+        this.emailSignature = emailSignature;
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/dto/ProfileUpdateRequest.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/ProfileUpdateRequest.java
@@ -1,28 +1,132 @@
 package com.example.rbac.users.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public class ProfileUpdateRequest {
     @NotBlank
-    private String fullName;
+    private String firstName;
+
+    @NotBlank
+    private String lastName;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    private String phoneNumber;
+
+    private String whatsappNumber;
+
+    private String facebookUrl;
+
+    private String linkedinUrl;
+
+    private String skypeId;
+
+    private String emailSignature;
+
+    private String oldPassword;
 
     @Size(min = 8)
-    private String password;
+    private String newPassword;
 
-    public String getFullName() {
-        return fullName;
+    private String confirmNewPassword;
+
+    public String getFirstName() {
+        return firstName;
     }
 
-    public void setFullName(String fullName) {
-        this.fullName = fullName;
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
     }
 
-    public String getPassword() {
-        return password;
+    public String getLastName() {
+        return lastName;
     }
 
-    public void setPassword(String password) {
-        this.password = password;
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getWhatsappNumber() {
+        return whatsappNumber;
+    }
+
+    public void setWhatsappNumber(String whatsappNumber) {
+        this.whatsappNumber = whatsappNumber;
+    }
+
+    public String getFacebookUrl() {
+        return facebookUrl;
+    }
+
+    public void setFacebookUrl(String facebookUrl) {
+        this.facebookUrl = facebookUrl;
+    }
+
+    public String getLinkedinUrl() {
+        return linkedinUrl;
+    }
+
+    public void setLinkedinUrl(String linkedinUrl) {
+        this.linkedinUrl = linkedinUrl;
+    }
+
+    public String getSkypeId() {
+        return skypeId;
+    }
+
+    public void setSkypeId(String skypeId) {
+        this.skypeId = skypeId;
+    }
+
+    public String getEmailSignature() {
+        return emailSignature;
+    }
+
+    public void setEmailSignature(String emailSignature) {
+        this.emailSignature = emailSignature;
+    }
+
+    public String getOldPassword() {
+        return oldPassword;
+    }
+
+    public void setOldPassword(String oldPassword) {
+        this.oldPassword = oldPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public String getConfirmNewPassword() {
+        return confirmNewPassword;
+    }
+
+    public void setConfirmNewPassword(String confirmNewPassword) {
+        this.confirmNewPassword = confirmNewPassword;
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/dto/UpdateUserRequest.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/UpdateUserRequest.java
@@ -12,7 +12,10 @@ public class UpdateUserRequest {
     private String email;
 
     @NotBlank
-    private String fullName;
+    private String firstName;
+
+    @NotBlank
+    private String lastName;
 
     private boolean active = true;
 
@@ -25,6 +28,18 @@ public class UpdateUserRequest {
 
     private Set<String> revokedPermissionKeys;
 
+    private String phoneNumber;
+
+    private String whatsappNumber;
+
+    private String facebookUrl;
+
+    private String linkedinUrl;
+
+    private String skypeId;
+
+    private String emailSignature;
+
     public String getEmail() {
         return email;
     }
@@ -33,12 +48,20 @@ public class UpdateUserRequest {
         this.email = email;
     }
 
-    public String getFullName() {
-        return fullName;
+    public String getFirstName() {
+        return firstName;
     }
 
-    public void setFullName(String fullName) {
-        this.fullName = fullName;
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
     }
 
     public boolean isActive() {
@@ -79,5 +102,53 @@ public class UpdateUserRequest {
 
     public void setRevokedPermissionKeys(Set<String> revokedPermissionKeys) {
         this.revokedPermissionKeys = revokedPermissionKeys;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getWhatsappNumber() {
+        return whatsappNumber;
+    }
+
+    public void setWhatsappNumber(String whatsappNumber) {
+        this.whatsappNumber = whatsappNumber;
+    }
+
+    public String getFacebookUrl() {
+        return facebookUrl;
+    }
+
+    public void setFacebookUrl(String facebookUrl) {
+        this.facebookUrl = facebookUrl;
+    }
+
+    public String getLinkedinUrl() {
+        return linkedinUrl;
+    }
+
+    public void setLinkedinUrl(String linkedinUrl) {
+        this.linkedinUrl = linkedinUrl;
+    }
+
+    public String getSkypeId() {
+        return skypeId;
+    }
+
+    public void setSkypeId(String skypeId) {
+        this.skypeId = skypeId;
+    }
+
+    public String getEmailSignature() {
+        return emailSignature;
+    }
+
+    public void setEmailSignature(String emailSignature) {
+        this.emailSignature = emailSignature;
     }
 }

--- a/backend/src/main/java/com/example/rbac/users/dto/UserDto.java
+++ b/backend/src/main/java/com/example/rbac/users/dto/UserDto.java
@@ -7,6 +7,14 @@ public class UserDto {
     private Long id;
     private String email;
     private String fullName;
+    private String firstName;
+    private String lastName;
+    private String phoneNumber;
+    private String whatsappNumber;
+    private String facebookUrl;
+    private String linkedinUrl;
+    private String skypeId;
+    private String emailSignature;
     private boolean active;
     private Set<String> roles;
     private Set<String> permissions;
@@ -37,6 +45,70 @@ public class UserDto {
 
     public void setFullName(String fullName) {
         this.fullName = fullName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getWhatsappNumber() {
+        return whatsappNumber;
+    }
+
+    public void setWhatsappNumber(String whatsappNumber) {
+        this.whatsappNumber = whatsappNumber;
+    }
+
+    public String getFacebookUrl() {
+        return facebookUrl;
+    }
+
+    public void setFacebookUrl(String facebookUrl) {
+        this.facebookUrl = facebookUrl;
+    }
+
+    public String getLinkedinUrl() {
+        return linkedinUrl;
+    }
+
+    public void setLinkedinUrl(String linkedinUrl) {
+        this.linkedinUrl = linkedinUrl;
+    }
+
+    public String getSkypeId() {
+        return skypeId;
+    }
+
+    public void setSkypeId(String skypeId) {
+        this.skypeId = skypeId;
+    }
+
+    public String getEmailSignature() {
+        return emailSignature;
+    }
+
+    public void setEmailSignature(String emailSignature) {
+        this.emailSignature = emailSignature;
     }
 
     public boolean isActive() {

--- a/backend/src/main/java/com/example/rbac/users/model/User.java
+++ b/backend/src/main/java/com/example/rbac/users/model/User.java
@@ -25,6 +25,30 @@ public class User {
     @Column(name = "full_name", nullable = false, length = 150)
     private String fullName;
 
+    @Column(name = "first_name", nullable = false, length = 100)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false, length = 100)
+    private String lastName;
+
+    @Column(name = "phone_number", length = 50)
+    private String phoneNumber;
+
+    @Column(name = "whatsapp_number", length = 50)
+    private String whatsappNumber;
+
+    @Column(name = "facebook_url", length = 255)
+    private String facebookUrl;
+
+    @Column(name = "linkedin_url", length = 255)
+    private String linkedinUrl;
+
+    @Column(name = "skype_id", length = 100)
+    private String skypeId;
+
+    @Column(name = "email_signature")
+    private String emailSignature;
+
     @Column(name = "is_active", nullable = false)
     private boolean active = true;
 
@@ -60,11 +84,22 @@ public class User {
         Instant now = Instant.now();
         createdAt = now;
         updatedAt = now;
+        refreshFullName();
     }
 
     @PreUpdate
     public void preUpdate() {
         updatedAt = Instant.now();
+        refreshFullName();
+    }
+
+    private void refreshFullName() {
+        String first = firstName != null ? firstName.trim() : "";
+        String last = lastName != null ? lastName.trim() : "";
+        String combined = (first + " " + last).trim();
+        if (!combined.isEmpty()) {
+            fullName = combined;
+        }
     }
 
     public Long getId() {
@@ -97,6 +132,70 @@ public class User {
 
     public void setFullName(String fullName) {
         this.fullName = fullName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getWhatsappNumber() {
+        return whatsappNumber;
+    }
+
+    public void setWhatsappNumber(String whatsappNumber) {
+        this.whatsappNumber = whatsappNumber;
+    }
+
+    public String getFacebookUrl() {
+        return facebookUrl;
+    }
+
+    public void setFacebookUrl(String facebookUrl) {
+        this.facebookUrl = facebookUrl;
+    }
+
+    public String getLinkedinUrl() {
+        return linkedinUrl;
+    }
+
+    public void setLinkedinUrl(String linkedinUrl) {
+        this.linkedinUrl = linkedinUrl;
+    }
+
+    public String getSkypeId() {
+        return skypeId;
+    }
+
+    public void setSkypeId(String skypeId) {
+        this.skypeId = skypeId;
+    }
+
+    public String getEmailSignature() {
+        return emailSignature;
+    }
+
+    public void setEmailSignature(String emailSignature) {
+        this.emailSignature = emailSignature;
     }
 
     public boolean isActive() {

--- a/backend/src/main/java/com/example/rbac/users/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/rbac/users/repository/UserRepository.java
@@ -30,4 +30,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT COUNT(DISTINCT u) FROM User u JOIN u.roles r WHERE UPPER(r.key) = UPPER(:roleKey)")
     long countByRoleKeyIgnoreCase(@Param("roleKey") String roleKey);
+
+    boolean existsByEmailAndIdNot(String email, Long id);
 }

--- a/backend/src/main/resources/db/migration/V10__user_profile_fields.sql
+++ b/backend/src/main/resources/db/migration/V10__user_profile_fields.sql
@@ -1,0 +1,30 @@
+ALTER TABLE users
+    ADD COLUMN first_name VARCHAR(100),
+    ADD COLUMN last_name VARCHAR(100),
+    ADD COLUMN phone_number VARCHAR(50),
+    ADD COLUMN whatsapp_number VARCHAR(50),
+    ADD COLUMN facebook_url VARCHAR(255),
+    ADD COLUMN linkedin_url VARCHAR(255),
+    ADD COLUMN skype_id VARCHAR(100),
+    ADD COLUMN email_signature TEXT;
+
+UPDATE users
+SET first_name = COALESCE(NULLIF(split_part(full_name, ' ', 1), ''), full_name),
+    last_name = CASE
+        WHEN POSITION(' ' IN full_name) > 0 THEN COALESCE(NULLIF(BTRIM(SUBSTRING(full_name FROM POSITION(' ' IN full_name) + 1)), ''), '')
+        ELSE ''
+    END;
+
+UPDATE users
+SET first_name = full_name
+WHERE first_name IS NULL;
+
+UPDATE users
+SET last_name = ''
+WHERE last_name IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN first_name SET NOT NULL,
+    ALTER COLUMN last_name SET NOT NULL,
+    ALTER COLUMN first_name SET DEFAULT '',
+    ALTER COLUMN last_name SET DEFAULT '';

--- a/backend/src/main/resources/db/migration/V9__activity_module.sql
+++ b/backend/src/main/resources/db/migration/V9__activity_module.sql
@@ -1,0 +1,81 @@
+CREATE TABLE activity_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    occurred_at DATETIME(6) NOT NULL,
+    user_id BIGINT NULL,
+    user_name VARCHAR(150) NOT NULL,
+    user_role VARCHAR(150) NULL,
+    department VARCHAR(150) NULL,
+    module_name VARCHAR(150) NULL,
+    activity_type VARCHAR(100) NOT NULL,
+    description VARCHAR(1000) NULL,
+    status VARCHAR(50) NULL,
+    ip_address VARCHAR(45) NULL,
+    device VARCHAR(150) NULL,
+    context TEXT NULL
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_activity_logs_occurred_at ON activity_logs (occurred_at);
+CREATE INDEX idx_activity_logs_module ON activity_logs (module_name);
+CREATE INDEX idx_activity_logs_activity_type ON activity_logs (activity_type);
+CREATE INDEX idx_activity_logs_status ON activity_logs (status);
+
+INSERT INTO activity_logs (
+    occurred_at,
+    user_id,
+    user_name,
+    user_role,
+    department,
+    module_name,
+    activity_type,
+    description,
+    status,
+    ip_address,
+    device,
+    context
+) VALUES
+('2024-03-18 09:12:35', 1, 'Super Admin', 'SUPER_ADMIN', 'Operations', 'Users', 'UPDATE',
+ 'Updated permissions for user "finance@demo.io" to include invoice export rights.', 'SUCCESS', '192.168.1.10', 'Chrome on macOS',
+ '{"before": {"permissions": ["INVOICE_VIEW", "INVOICE_UPDATE"]}, "after": {"permissions": ["INVOICE_VIEW", "INVOICE_UPDATE", "INVOICES_EXPORT"]}}'),
+('2024-03-18 10:04:18', 2, 'Admin User', 'ADMIN', 'Customer Success', 'Customers', 'CREATE',
+ 'Created a new customer record for "Globex Manufacturing".', 'SUCCESS', '192.168.1.24', 'Edge on Windows',
+ '{"customer": {"name": "Globex Manufacturing", "email": "ops@globex.com"}}'),
+('2024-03-18 10:32:49', 3, 'Finance User', 'FINANCE', 'Accounting', 'Invoices', 'EXPORT',
+ 'Exported 24 invoices to CSV using the finance dashboard.', 'SUCCESS', '10.10.0.54', 'Safari on iPad',
+ '{"filters": {"status": "PAID", "from": "2024-02-01", "to": "2024-03-01"}, "format": "CSV"}'),
+('2024-03-18 11:14:02', 2, 'Admin User', 'ADMIN', 'Customer Success', 'Users', 'DISABLE',
+ 'Disabled login for user "contractor@demo.io" after contract end.', 'SUCCESS', '192.168.1.24', 'Edge on Windows',
+ '{"targetUser": "contractor@demo.io", "reason": "Contract expired"}'),
+('2024-03-18 12:06:41', 1, 'Super Admin', 'SUPER_ADMIN', 'Operations', 'Settings', 'UPDATE',
+ 'Updated the primary brand color to match new guidelines.', 'SUCCESS', '192.168.1.10', 'Chrome on macOS',
+ '{"before": {"appearance.primary_color": "#2563EB"}, "after": {"appearance.primary_color": "#1D4ED8"}}'),
+('2024-03-18 12:25:09', 4, 'API Client', 'SYSTEM', 'Integrations', 'Auth', 'LOGIN',
+ 'Service account authenticated using client credentials.', 'SUCCESS', '52.32.101.18', 'API Client',
+ '{"clientId": "svc-analytics", "scopes": ["analytics.read"]}'),
+('2024-03-18 13:17:32', 3, 'Finance User', 'FINANCE', 'Accounting', 'Invoices', 'UPDATE',
+ 'Adjusted invoice INV-1001 subtotal after reconciliation.', 'SUCCESS', '10.10.0.54', 'Safari on iPad',
+ '{"invoice": "INV-1001", "before": {"subtotal": 1500.00}, "after": {"subtotal": 1525.00}}'),
+('2024-03-18 14:02:11', 5, 'Security Monitor', 'SYSTEM', 'Security', 'Auth', 'LOGIN',
+ 'Failed login attempt detected for user "admin@demo.io".', 'FAILURE', '203.0.113.45', 'Firefox on Linux',
+ '{"username": "admin@demo.io", "result": "INVALID_PASSWORD"}'),
+('2024-03-18 14:48:27', 2, 'Admin User', 'ADMIN', 'Customer Success', 'Customers', 'UPDATE',
+ 'Updated billing contact information for "Soylent Industries".', 'SUCCESS', '192.168.1.24', 'Edge on Windows',
+ '{"customer": "Soylent Industries", "before": {"email": "finance@soylent.co"}, "after": {"email": "billing@soylent.co"}}'),
+('2024-03-18 15:36:55', 1, 'Super Admin', 'SUPER_ADMIN', 'Operations', 'Permissions', 'DELETE',
+ 'Removed legacy permission "REPORT_EXPORT" from the system.', 'SUCCESS', '192.168.1.10', 'Chrome on macOS',
+ '{"permission": "REPORT_EXPORT", "impact": "No active roles assigned."}');
+
+INSERT IGNORE INTO permissions (code, name) VALUES
+  ('ACTIVITY_VIEW', 'View Activity Log'),
+  ('ACTIVITY_EXPORT', 'Export Activity Log');
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code IN ('ACTIVITY_VIEW', 'ACTIVITY_EXPORT')
+WHERE r.code IN ('SUPER_ADMIN');
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code = 'ACTIVITY_VIEW'
+WHERE r.code IN ('ADMIN');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import SettingsPage from './pages/SettingsPage';
 import { fetchTheme } from './features/settings/settingsSlice';
 import { selectApplicationName, selectPrimaryColor } from './features/settings/selectors';
 import { applyPrimaryColor } from './utils/colors';
+import ActivityPage from './pages/ActivityPage';
+import ActivityDetailPage from './pages/ActivityDetailPage';
 
 const App = () => {
   const dispatch = useAppDispatch();
@@ -149,6 +151,10 @@ const App = () => {
             }
           >
             <Route path="/invoices" element={<InvoicesPage />} />
+          </Route>
+          <Route element={<PermissionRoute required={['ACTIVITY_VIEW']} />}>
+            <Route path="/activity" element={<ActivityPage />} />
+            <Route path="/activity/:id" element={<ActivityDetailPage />} />
           </Route>
           <Route element={<PermissionRoute required={['SETTINGS_VIEW']} />}>
             <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/FilterDropdown.tsx
+++ b/frontend/src/components/FilterDropdown.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+export interface FilterDropdownProps {
+  label: string;
+  placeholder?: string;
+  options: string[] | undefined;
+  values: string[];
+  onChange: (values: string[]) => void;
+  disabled?: boolean;
+}
+
+const FilterDropdown = ({
+  label,
+  placeholder = 'Select',
+  options,
+  values,
+  onChange,
+  disabled = false
+}: FilterDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (!containerRef.current || containerRef.current.contains(event.target as Node)) {
+        return;
+      }
+      setIsOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (disabled) {
+      setIsOpen(false);
+    }
+  }, [disabled]);
+
+  const title = useMemo(() => {
+    if (!values.length) {
+      return placeholder;
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values.length} selected`;
+  }, [placeholder, values]);
+
+  const toggleValue = (value: string) => {
+    if (values.includes(value)) {
+      onChange(values.filter((current) => current !== value));
+    } else {
+      onChange([...values, value]);
+    }
+  };
+
+  return (
+    <div className="relative space-y-1" ref={containerRef}>
+      <label className="block text-sm font-medium text-slate-600">{label}</label>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setIsOpen((open) => !open)}
+        className="flex w-full items-center justify-between rounded-lg border border-slate-300 bg-white px-3 py-2 text-left text-sm font-medium text-slate-700 shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <span className={values.length ? 'truncate' : 'text-slate-400'}>{title}</span>
+        <svg
+          className={`ml-2 h-4 w-4 text-slate-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.23 7.21a.75.75 0 011.06.02L10 11.085l3.71-3.854a.75.75 0 011.08 1.04l-4.25 4.417a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="absolute left-0 right-0 z-30 mt-2 min-w-[16rem] max-w-sm overflow-hidden rounded-xl border border-slate-200 bg-white shadow-xl">
+          <div className="max-h-60 overflow-y-auto p-3">
+            {!options?.length && (
+              <div className="py-6 text-center text-sm text-slate-400">No options available</div>
+            )}
+            {options?.map((option) => {
+              const checked = values.includes(option);
+              return (
+                <label
+                  key={option}
+                  className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 text-sm text-slate-600 transition hover:bg-slate-100"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleValue(option)}
+                    className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                  />
+                  <span className="truncate text-slate-700">{option}</span>
+                </label>
+              );
+            })}
+          </div>
+          <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-500">
+            <span>{values.length ? `${values.length} selected` : 'No selections'}</span>
+            <button
+              type="button"
+              onClick={() => onChange([])}
+              className="font-medium text-primary transition hover:text-primary/80"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FilterDropdown;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { logout } from '../features/auth/authSlice';
@@ -23,6 +23,8 @@ const Layout = () => {
   const applicationName = useAppSelector(selectApplicationName);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const profileMenuRef = useRef<HTMLDivElement | null>(null);
 
   const brandName = applicationName?.trim() || 'RBAC Portal';
   const brandInitials = useMemo(() => {
@@ -90,6 +92,15 @@ const Layout = () => {
       });
     }
 
+    if (tabs.includes('Activity')) {
+      items.push({
+        key: 'activity',
+        label: 'Activity',
+        to: '/activity',
+        icon: '📝'
+      });
+    }
+
     if (tabs.includes('Settings')) {
       items.push({
         key: 'settings',
@@ -127,6 +138,23 @@ const Layout = () => {
     });
   }, [location.pathname, navigation]);
 
+  useEffect(() => {
+    const handleClickAway = (event: MouseEvent) => {
+      if (!profileMenuRef.current) {
+        return;
+      }
+      if (!profileMenuRef.current.contains(event.target as Node)) {
+        setProfileMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickAway);
+    return () => document.removeEventListener('mousedown', handleClickAway);
+  }, []);
+
+  useEffect(() => {
+    setProfileMenuOpen(false);
+  }, [location.pathname]);
+
   const toggleSection = (key: string) => {
     setExpandedSections((prev) => ({ ...prev, [key]: !(prev[key] ?? true) }));
   };
@@ -153,6 +181,11 @@ const Layout = () => {
     }
     dispatch(logout());
     navigate('/login', { replace: true });
+  };
+
+  const handleProfileNavigate = () => {
+    setProfileMenuOpen(false);
+    navigate('/profile');
   };
 
   return (
@@ -192,22 +225,49 @@ const Layout = () => {
           </button>
         </div>
         <div className="px-3">
-          <div
-            className={`mt-6 rounded-xl border border-slate-200 bg-slate-50 p-3 transition-all ${
-              sidebarCollapsed ? 'items-center px-0 py-4' : 'flex items-center gap-3'
-            }`}
-          >
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
-              {getInitials()}
-            </div>
-            {!sidebarCollapsed && user && (
-              <div className="min-w-0">
-                <p className="truncate text-sm font-semibold text-slate-800">{user.fullName}</p>
-                <p className="truncate text-xs text-slate-500">{user.email}</p>
+          <div className="relative" ref={profileMenuRef}>
+            <button
+              type="button"
+              onClick={() => setProfileMenuOpen((prev) => !prev)}
+              className={`mt-6 w-full rounded-xl border border-slate-200 bg-slate-50 p-3 text-left transition-all ${
+                sidebarCollapsed ? 'flex flex-col items-center gap-3 px-0 py-4' : 'flex items-center gap-3'
+              }`}
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                {getInitials()}
               </div>
-            )}
-            {!sidebarCollapsed && !user && (
-              <p className="text-sm font-medium text-slate-600">Welcome</p>
+              {!sidebarCollapsed && user && (
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold text-slate-800">{user.fullName}</p>
+                  <p className="truncate text-xs text-slate-500">{user.email}</p>
+                </div>
+              )}
+              {!sidebarCollapsed && !user && (
+                <p className="text-sm font-medium text-slate-600">Welcome</p>
+              )}
+            </button>
+            {profileMenuOpen && !sidebarCollapsed && (
+              <div className="absolute left-0 right-0 z-20 mt-2 rounded-xl border border-slate-200 bg-white shadow-lg">
+                <button
+                  type="button"
+                  onClick={handleProfileNavigate}
+                  className="flex w-full items-center gap-3 rounded-t-xl px-4 py-3 text-sm text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                >
+                  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-base text-primary">👤</span>
+                  <span>Edit profile</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setProfileMenuOpen(false);
+                    handleLogout();
+                  }}
+                  className="flex w-full items-center gap-3 rounded-b-xl px-4 py-3 text-sm text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+                >
+                  <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-rose-50 text-base text-rose-500">⏻</span>
+                  <span>Sign out</span>
+                </button>
+              </div>
             )}
           </div>
         </div>

--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -50,7 +50,7 @@ export const login = createAsyncThunk<
   }
 });
 
-export const signup = createAsyncThunk<AuthResponse, { email: string; password: string; fullName: string }>(
+export const signup = createAsyncThunk<AuthResponse, { email: string; password: string; firstName: string; lastName: string }>(
   'auth/signup',
   async (payload) => {
     const { data } = await api.post<AuthResponse>('/auth/signup', payload);

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -1,0 +1,189 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '../services/http';
+import type { ActivityLogDetail } from '../types/models';
+import { extractErrorMessage } from '../utils/errors';
+
+const formatDateTime = (value: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(value));
+
+const renderContextValue = (value: unknown) => {
+  if (Array.isArray(value)) {
+    if (!value.length) {
+      return <span className="text-sm text-slate-500">—</span>;
+    }
+    return (
+      <ul className="list-disc space-y-1 pl-5 text-sm text-slate-700">
+        {value.map((item, index) => (
+          <li key={index}>{renderContextValue(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (value && typeof value === 'object') {
+    return (
+      <pre className="whitespace-pre-wrap break-words rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  if (value === null || value === undefined) {
+    return <span className="text-sm text-slate-500">—</span>;
+  }
+
+  return <span className="text-sm text-slate-700">{String(value)}</span>;
+};
+
+const renderStatusBadge = (status?: string | null) => {
+  if (!status) {
+    return <span className="text-slate-400">—</span>;
+  }
+  const normalized = status.toUpperCase();
+  const isSuccess = normalized === 'SUCCESS';
+  const isFailure = normalized === 'FAILURE' || normalized === 'ERROR';
+  const badgeClass = isSuccess
+    ? 'bg-emerald-100 text-emerald-700'
+    : isFailure
+    ? 'bg-rose-100 text-rose-700'
+    : 'bg-slate-100 text-slate-700';
+  return <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${badgeClass}`}>{normalized}</span>;
+};
+
+const ActivityDetailPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+
+  const detailQuery = useQuery<ActivityLogDetail>({
+    queryKey: ['activity', 'detail', id],
+    enabled: Boolean(id),
+    queryFn: async () => {
+      const { data } = await api.get<ActivityLogDetail>(`/activity/${id}`);
+      return data;
+    }
+  });
+
+  const handleBack = () => {
+    navigate('/activity');
+  };
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center text-sm text-slate-500">
+        Loading activity details…
+      </div>
+    );
+  }
+
+  if (detailQuery.isError || !detailQuery.data) {
+    return (
+      <div className="space-y-6">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="inline-flex items-center gap-2 rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+        >
+          ← Back to Activity
+        </button>
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-600">
+          {extractErrorMessage(detailQuery.error, 'Unable to load the selected activity. It may have been removed.')}
+        </div>
+      </div>
+    );
+  }
+
+  const detail = detailQuery.data;
+
+  return (
+    <div className="space-y-6">
+      <button
+        type="button"
+        onClick={handleBack}
+        className="inline-flex items-center gap-2 rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+      >
+        ← Back to Activity
+      </button>
+
+      <div className="space-y-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800">Activity details</h1>
+          <p className="text-sm text-slate-500">
+            Review the complete metadata captured for this action.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Timestamp</div>
+            <div className="mt-1 text-sm font-medium text-slate-800">{formatDateTime(detail.occurredAt)}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Status</div>
+            <div className="mt-1">{renderStatusBadge(detail.status)}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">User</div>
+            <div className="mt-1 text-sm font-medium text-slate-800">{detail.userName}</div>
+            <div className="text-xs text-slate-500">{detail.userId ? `User ID: ${detail.userId}` : 'User ID not captured'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Role &amp; Department</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.userRole ?? '—'}</div>
+            <div className="text-xs text-slate-500">{detail.department ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Module</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.module ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Activity type</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.activityType}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">IP address</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.ipAddress ?? '—'}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400">Device</div>
+            <div className="mt-1 text-sm text-slate-700">{detail.device ?? '—'}</div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs uppercase tracking-wide text-slate-400">Description</div>
+          <div className="mt-2 rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            {detail.description ?? 'No additional description provided.'}
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs uppercase tracking-wide text-slate-400">Context</div>
+          <div className="mt-2 space-y-3">
+            {detail.context && Object.keys(detail.context).length > 0 ? (
+              Object.entries(detail.context).map(([key, value]) => (
+                <div key={key}>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">{key}</div>
+                  <div className="mt-1">{renderContextValue(value)}</div>
+                </div>
+              ))
+            ) : detail.rawContext ? (
+              <pre className="whitespace-pre-wrap break-words rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
+                {detail.rawContext}
+              </pre>
+            ) : (
+              <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+                No contextual metadata recorded for this activity.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ActivityDetailPage;

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -1,0 +1,763 @@
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import DataTable from '../components/DataTable';
+import SortableColumnHeader from '../components/SortableColumnHeader';
+import ExportMenu from '../components/ExportMenu';
+import FilterDropdown from '../components/FilterDropdown';
+import api from '../services/http';
+import { useAppSelector } from '../app/hooks';
+import { hasAnyPermission } from '../utils/permissions';
+import type { PermissionKey } from '../types/auth';
+import type { ActivityFilterOptions, ActivityLogEntry, Pagination } from '../types/models';
+import { extractErrorMessage } from '../utils/errors';
+import { useToast } from '../components/ToastProvider';
+import { exportDataset, type ExportFormat } from '../utils/exporters';
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
+
+const formatDateTime = (value: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(value));
+
+type ActivitySortField = 'timestamp' | 'user' | 'activityType' | 'module' | 'status';
+
+type SelectChangeEvent = ChangeEvent<HTMLSelectElement>;
+
+const ActivityPage = () => {
+  const navigate = useNavigate();
+  const { permissions } = useAppSelector((state) => state.auth);
+  const grantedPermissions = permissions as PermissionKey[];
+  const { notify } = useToast();
+  const canExport = hasAnyPermission(grantedPermissions, ['ACTIVITY_EXPORT']);
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_OPTIONS[0]);
+  const [sort, setSort] = useState<{ field: ActivitySortField; direction: 'asc' | 'desc' }>({
+    field: 'timestamp',
+    direction: 'desc'
+  });
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
+  const [userFilter, setUserFilter] = useState('');
+  const [roleFilter, setRoleFilter] = useState<string[]>([]);
+  const [departmentFilter, setDepartmentFilter] = useState<string[]>([]);
+  const [moduleFilter, setModuleFilter] = useState<string[]>([]);
+  const [typeFilter, setTypeFilter] = useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  const [ipFilter, setIpFilter] = useState('');
+  const [deviceFilter, setDeviceFilter] = useState<string[]>([]);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [isExporting, setIsExporting] = useState(false);
+
+  const goToFirstPage = useCallback(() => setPage(0), []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearch(searchDraft.trim());
+      goToFirstPage();
+    }, 300);
+
+    return () => window.clearTimeout(timer);
+  }, [goToFirstPage, searchDraft]);
+
+  const filtersKey = useMemo(
+    () => ({
+      user: userFilter.trim(),
+      roles: [...roleFilter].sort(),
+      departments: [...departmentFilter].sort(),
+      modules: [...moduleFilter].sort(),
+      types: [...typeFilter].sort(),
+      statuses: [...statusFilter].sort(),
+      ip: ipFilter.trim(),
+      devices: [...deviceFilter].sort(),
+      startDate,
+      endDate,
+      search
+    }),
+    [
+      userFilter,
+      roleFilter,
+      departmentFilter,
+      moduleFilter,
+      typeFilter,
+      statusFilter,
+      ipFilter,
+      deviceFilter,
+      startDate,
+      endDate,
+      search
+    ]
+  );
+
+  const buildQueryParams = (overrides?: { page?: number; size?: number }) => {
+    const params = new URLSearchParams();
+    const nextPage = overrides?.page ?? page;
+    const nextSize = overrides?.size ?? pageSize;
+    params.set('page', String(nextPage));
+    params.set('size', String(nextSize));
+    params.set('sort', sort.field);
+    params.set('direction', sort.direction);
+    if (search) {
+      params.set('search', search);
+    }
+    const trimmedUser = userFilter.trim();
+    if (trimmedUser) {
+      params.set('user', trimmedUser);
+    }
+    roleFilter.forEach((value) => params.append('role', value));
+    departmentFilter.forEach((value) => params.append('department', value));
+    moduleFilter.forEach((value) => params.append('module', value));
+    typeFilter.forEach((value) => params.append('type', value));
+    statusFilter.forEach((value) => params.append('status', value));
+    const trimmedIp = ipFilter.trim();
+    if (trimmedIp) {
+      params.set('ipAddress', trimmedIp);
+    }
+    deviceFilter.forEach((value) => params.append('device', value));
+    if (startDate) {
+      const startIso = new Date(`${startDate}T00:00:00`).toISOString();
+      params.set('startDate', startIso);
+    }
+    if (endDate) {
+      const endIso = new Date(`${endDate}T23:59:59.999`).toISOString();
+      params.set('endDate', endIso);
+    }
+    return params;
+  };
+
+  const filtersQuery = useQuery<ActivityFilterOptions>({
+    queryKey: ['activity', 'filters'],
+    queryFn: async () => {
+      const { data } = await api.get<ActivityFilterOptions>('/activity/filters');
+      return data;
+    }
+  });
+
+  const activityQuery = useQuery<Pagination<ActivityLogEntry>>({
+    queryKey: ['activity', 'list', { page, pageSize, sort, filtersKey }],
+    queryFn: async () => {
+      const { data } = await api.get<Pagination<ActivityLogEntry>>('/activity', {
+        params: buildQueryParams()
+      });
+      return data;
+    }
+  });
+
+  const activityData = activityQuery.data as Pagination<ActivityLogEntry> | undefined;
+  const activities: ActivityLogEntry[] = activityData?.content ?? [];
+  const totalElements = activityData?.totalElements ?? 0;
+  const totalPages = activityData?.totalPages ?? 0;
+  const isLoading = activityQuery.isLoading;
+  const hasError = activityQuery.isError;
+  const errorMessage = hasError
+    ? extractErrorMessage(activityQuery.error, 'Unable to load activity log records.')
+    : null;
+
+  useEffect(() => {
+    if (!isLoading && !hasError && totalPages > 0 && page >= totalPages) {
+      setPage(totalPages - 1);
+    }
+  }, [hasError, isLoading, page, totalPages]);
+
+  const handleSort = (field: ActivitySortField) => {
+    setSort((prev) => {
+      if (prev.field === field) {
+        const nextDirection = prev.direction === 'asc' ? 'desc' : 'asc';
+        return { field, direction: nextDirection };
+      }
+      return { field, direction: field === 'timestamp' ? 'desc' : 'asc' };
+    });
+    goToFirstPage();
+  };
+
+  const handlePageSizeChange = (event: SelectChangeEvent) => {
+    const nextSize = Number(event.target.value);
+    setPageSize(nextSize);
+    goToFirstPage();
+  };
+
+  const handlePreviousPage = () => {
+    setPage((prev) => Math.max(prev - 1, 0));
+  };
+
+  const handleNextPage = () => {
+    if (page + 1 < totalPages) {
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  const handleClearFilters = () => {
+    setUserFilter('');
+    setRoleFilter([]);
+    setDepartmentFilter([]);
+    setModuleFilter([]);
+    setTypeFilter([]);
+    setStatusFilter([]);
+    setIpFilter('');
+    setDeviceFilter([]);
+    setStartDate('');
+    setEndDate('');
+    setSearch('');
+    setSearchDraft('');
+    goToFirstPage();
+  };
+
+  const handleExport = async (format: ExportFormat) => {
+    if (!canExport || isExporting) {
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const params = buildQueryParams({ page: 0, size: Math.max(pageSize, 1000) });
+      params.set('size', '1000');
+      const { data } = await api.get<Pagination<ActivityLogEntry>>('/activity', { params });
+      if (!data.content.length) {
+        notify({ type: 'error', message: 'There are no activity records to export for the selected filters.' });
+        return;
+      }
+
+      const rows = data.content.map((activity) => ({
+        timestamp: formatDateTime(activity.occurredAt),
+        user: activity.userName,
+        role: activity.userRole ?? '—',
+        department: activity.department ?? '—',
+        module: activity.module ?? '—',
+        type: activity.activityType,
+        status: activity.status ?? '—',
+        ipAddress: activity.ipAddress ?? '—',
+        device: activity.device ?? '—',
+        description: activity.description ?? '—'
+      }));
+
+      const columns = [
+        { key: 'timestamp', header: 'Timestamp' },
+        { key: 'user', header: 'User' },
+        { key: 'role', header: 'Role' },
+        { key: 'department', header: 'Department' },
+        { key: 'module', header: 'Module' },
+        { key: 'type', header: 'Activity Type' },
+        { key: 'status', header: 'Status' },
+        { key: 'ipAddress', header: 'IP Address' },
+        { key: 'device', header: 'Device' },
+        { key: 'description', header: 'Description' }
+      ];
+
+      exportDataset({
+        format,
+        columns,
+        rows,
+        fileName: 'activity-log',
+        title: 'Activity Log Export'
+      });
+    } catch (error) {
+      notify({ type: 'error', message: 'Unable to export activity records. Please try again.' });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const renderStatusBadge = (status?: string | null) => {
+    if (!status) {
+      return <span className="text-slate-400">—</span>;
+    }
+    const normalized = status.toUpperCase();
+    const isSuccess = normalized === 'SUCCESS';
+    const isFailure = normalized === 'FAILURE' || normalized === 'ERROR';
+    const badgeClass = isSuccess
+      ? 'bg-emerald-100 text-emerald-700'
+      : isFailure
+      ? 'bg-rose-100 text-rose-700'
+      : 'bg-slate-100 text-slate-700';
+    return <span className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${badgeClass}`}>{normalized}</span>;
+  };
+
+  const formatDateOnly = (value: string) =>
+    new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(`${value}T00:00:00`));
+
+  const activeFilterChips = useMemo(
+    () => {
+      const chips: { key: string; label: string; onRemove: () => void }[] = [];
+      roleFilter.forEach((value) => {
+        chips.push({
+          key: `role:${value}`,
+          label: `Role: ${value}`,
+          onRemove: () => {
+            setRoleFilter((prev) => prev.filter((item) => item !== value));
+            goToFirstPage();
+          }
+        });
+      });
+      departmentFilter.forEach((value) => {
+        chips.push({
+          key: `department:${value}`,
+          label: `Department: ${value}`,
+          onRemove: () => {
+            setDepartmentFilter((prev) => prev.filter((item) => item !== value));
+            goToFirstPage();
+          }
+        });
+      });
+      moduleFilter.forEach((value) => {
+        chips.push({
+          key: `module:${value}`,
+          label: `Module: ${value}`,
+          onRemove: () => {
+            setModuleFilter((prev) => prev.filter((item) => item !== value));
+            goToFirstPage();
+          }
+        });
+      });
+      typeFilter.forEach((value) => {
+        chips.push({
+          key: `type:${value}`,
+          label: `Type: ${value}`,
+          onRemove: () => {
+            setTypeFilter((prev) => prev.filter((item) => item !== value));
+            goToFirstPage();
+          }
+        });
+      });
+      statusFilter.forEach((value) => {
+        chips.push({
+          key: `status:${value}`,
+          label: `Status: ${value}`,
+          onRemove: () => {
+            setStatusFilter((prev) => prev.filter((item) => item !== value));
+            goToFirstPage();
+          }
+        });
+      });
+      deviceFilter.forEach((value) => {
+        chips.push({
+          key: `device:${value}`,
+          label: `Device: ${value}`,
+          onRemove: () => {
+            setDeviceFilter((prev) => prev.filter((item) => item !== value));
+            goToFirstPage();
+          }
+        });
+      });
+      if (startDate) {
+        chips.push({
+          key: 'startDate',
+          label: `From: ${formatDateOnly(startDate)}`,
+          onRemove: () => {
+            setStartDate('');
+            goToFirstPage();
+          }
+        });
+      }
+      if (endDate) {
+        chips.push({
+          key: 'endDate',
+          label: `To: ${formatDateOnly(endDate)}`,
+          onRemove: () => {
+            setEndDate('');
+            goToFirstPage();
+          }
+        });
+      }
+      if (userFilter.trim()) {
+        chips.push({
+          key: 'user',
+          label: `User: ${userFilter.trim()}`,
+          onRemove: () => {
+            setUserFilter('');
+            goToFirstPage();
+          }
+        });
+      }
+      if (ipFilter.trim()) {
+        chips.push({
+          key: 'ip',
+          label: `IP: ${ipFilter.trim()}`,
+          onRemove: () => {
+            setIpFilter('');
+            goToFirstPage();
+          }
+        });
+      }
+      if (search.trim()) {
+        chips.push({
+          key: 'search',
+          label: `Search: ${search.trim()}`,
+          onRemove: () => {
+            setSearch('');
+            setSearchDraft('');
+            goToFirstPage();
+          }
+        });
+      }
+      return chips;
+    },
+    [
+      departmentFilter,
+      deviceFilter,
+      goToFirstPage,
+      ipFilter,
+      moduleFilter,
+      roleFilter,
+      search,
+      setDepartmentFilter,
+      setDeviceFilter,
+      setIpFilter,
+      setModuleFilter,
+      setRoleFilter,
+      setSearch,
+      setSearchDraft,
+      setStatusFilter,
+      setTypeFilter,
+      setUserFilter,
+      startDate,
+      statusFilter,
+      typeFilter,
+      userFilter,
+      endDate,
+      setStartDate,
+      setEndDate
+    ]
+  );
+
+  const from = totalElements === 0 ? 0 : page * pageSize + 1;
+  const to = Math.min((page + 1) * pageSize, totalElements);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800">Activity</h1>
+          <p className="text-sm text-slate-500">
+            Review a complete audit trail of user actions across the platform.
+          </p>
+        </div>
+        {canExport && (
+          <ExportMenu onSelect={handleExport} isBusy={isExporting} disabled={isLoading} />
+        )}
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="md:col-span-2 xl:col-span-2">
+            <label className="block text-sm font-medium text-slate-600">Search</label>
+            <input
+              type="search"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+              placeholder="Search descriptions, modules, users, or IP addresses"
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">User</label>
+            <input
+              type="text"
+              value={userFilter}
+              onChange={(event) => {
+                setUserFilter(event.target.value);
+                goToFirstPage();
+              }}
+              placeholder="Name or ID"
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">IP Address</label>
+            <input
+              type="text"
+              value={ipFilter}
+              onChange={(event) => {
+                setIpFilter(event.target.value);
+                goToFirstPage();
+              }}
+              placeholder="e.g. 192.168.1.10"
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <FilterDropdown
+            label="Roles"
+            placeholder="All roles"
+            options={filtersQuery.data?.roles}
+            values={roleFilter}
+            onChange={(values) => {
+              setRoleFilter(values);
+              goToFirstPage();
+            }}
+            disabled={filtersQuery.isLoading || filtersQuery.isError}
+          />
+          <FilterDropdown
+            label="Departments"
+            placeholder="All departments"
+            options={filtersQuery.data?.departments}
+            values={departmentFilter}
+            onChange={(values) => {
+              setDepartmentFilter(values);
+              goToFirstPage();
+            }}
+            disabled={filtersQuery.isLoading || filtersQuery.isError}
+          />
+          <FilterDropdown
+            label="Modules"
+            placeholder="All modules"
+            options={filtersQuery.data?.modules}
+            values={moduleFilter}
+            onChange={(values) => {
+              setModuleFilter(values);
+              goToFirstPage();
+            }}
+            disabled={filtersQuery.isLoading || filtersQuery.isError}
+          />
+          <FilterDropdown
+            label="Activity Types"
+            placeholder="All activity types"
+            options={filtersQuery.data?.activityTypes}
+            values={typeFilter}
+            onChange={(values) => {
+              setTypeFilter(values);
+              goToFirstPage();
+            }}
+            disabled={filtersQuery.isLoading || filtersQuery.isError}
+          />
+          <FilterDropdown
+            label="Statuses"
+            placeholder="All statuses"
+            options={filtersQuery.data?.statuses}
+            values={statusFilter}
+            onChange={(values) => {
+              setStatusFilter(values);
+              goToFirstPage();
+            }}
+            disabled={filtersQuery.isLoading || filtersQuery.isError}
+          />
+          <FilterDropdown
+            label="Devices"
+            placeholder="All devices"
+            options={filtersQuery.data?.devices}
+            values={deviceFilter}
+            onChange={(values) => {
+              setDeviceFilter(values);
+              goToFirstPage();
+            }}
+            disabled={filtersQuery.isLoading || filtersQuery.isError}
+          />
+          <div>
+            <label className="block text-sm font-medium text-slate-600">Start Date</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(event) => {
+                setStartDate(event.target.value);
+                goToFirstPage();
+              }}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-600">End Date</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(event) => {
+                setEndDate(event.target.value);
+                goToFirstPage();
+              }}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+        </div>
+
+        {activeFilterChips.length > 0 && (
+          <div className="mt-6 flex flex-wrap items-center gap-2">
+            {activeFilterChips.map((chip) => (
+              <span
+                key={chip.key}
+                className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
+              >
+                {chip.label}
+                <button
+                  type="button"
+                  onClick={chip.onRemove}
+                  className="rounded-full p-1 text-primary transition hover:bg-primary/10"
+                  aria-label={`Remove ${chip.label}`}
+                >
+                  <svg className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path
+                      fillRule="evenodd"
+                      d="M10 8.586 4.707 3.293a1 1 0 0 0-1.414 1.414L8.586 10l-5.293 5.293a1 1 0 1 0 1.414 1.414L10 11.414l5.293 5.293a1 1 0 0 0 1.414-1.414L11.414 10l5.293-5.293A1 1 0 0 0 15.293 3.293L10 8.586Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </span>
+            ))}
+            <button
+              type="button"
+              onClick={handleClearFilters}
+              className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-100"
+            >
+              Clear all
+            </button>
+          </div>
+        )}
+      </div>
+
+      <DataTable
+        title="Activity log"
+        actions={
+          <div className="flex items-center gap-3">
+            <label className="text-sm text-slate-500">
+              Rows per page
+              <select
+                value={pageSize}
+                onChange={handlePageSizeChange}
+                className="ml-2 rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              >
+                {PAGE_SIZE_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        }
+      >
+        <thead className="bg-slate-50">
+          <tr>
+            <SortableColumnHeader
+              label="Timestamp"
+              field="timestamp"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <SortableColumnHeader
+              label="User"
+              field="user"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Role / Department</th>
+            <SortableColumnHeader
+              label="Module"
+              field="module"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <SortableColumnHeader
+              label="Activity Type"
+              field="activityType"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+            />
+            <SortableColumnHeader
+              label="Status"
+              field="status"
+              currentField={sort.field}
+              direction={sort.direction}
+              onSort={handleSort}
+              align="center"
+            />
+            <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Context</th>
+            <th className="hidden px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 lg:table-cell">
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 bg-white">
+          {isLoading && (
+            <tr>
+              <td colSpan={8} className="px-6 py-6 text-center text-sm text-slate-500">
+                Loading activity records…
+              </td>
+            </tr>
+          )}
+          {!isLoading && hasError && (
+            <tr>
+              <td colSpan={8} className="px-6 py-6 text-center text-sm text-rose-500">
+                {errorMessage}
+              </td>
+            </tr>
+          )}
+          {!isLoading && !hasError && activities.length === 0 && (
+            <tr>
+              <td colSpan={8} className="px-6 py-6 text-center text-sm text-slate-500">
+                No activity records found for the selected filters.
+              </td>
+            </tr>
+          )}
+          {!isLoading && !hasError &&
+            activities.map((activity) => (
+              <tr
+                key={activity.id}
+                onClick={() => navigate(`/activity/${activity.id}`)}
+                className="cursor-pointer transition hover:bg-slate-50"
+              >
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">
+                  {formatDateTime(activity.occurredAt)}
+                </td>
+                <td className="px-4 py-3 text-sm font-medium text-slate-800">{activity.userName}</td>
+                <td className="px-4 py-3 text-xs text-slate-500">
+                  <div className="font-medium text-slate-700">{activity.userRole ?? '—'}</div>
+                  <div>{activity.department ?? '—'}</div>
+                </td>
+                <td className="px-4 py-3 text-sm text-slate-600">{activity.module ?? '—'}</td>
+                <td className="px-4 py-3 text-sm text-slate-600">{activity.activityType}</td>
+                <td className="px-4 py-3 text-center">{renderStatusBadge(activity.status)}</td>
+                <td className="px-4 py-3 text-sm text-slate-600">
+                  <div className="font-medium text-slate-700">{activity.ipAddress ?? '—'}</div>
+                  <div className="text-xs text-slate-500">{activity.device ?? '—'}</div>
+                </td>
+                <td className="hidden px-4 py-3 text-sm text-slate-600 lg:table-cell">
+                  <div className="max-w-md whitespace-normal" title={activity.description ?? undefined}>
+                    {activity.description ?? '—'}
+                  </div>
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </DataTable>
+
+      <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white px-6 py-4 text-sm shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-slate-600">
+          Showing <span className="font-semibold text-slate-800">{from}</span> to{' '}
+          <span className="font-semibold text-slate-800">{to}</span> of{' '}
+          <span className="font-semibold text-slate-800">{totalElements}</span> activity records
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handlePreviousPage}
+            disabled={page === 0}
+            className="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Previous
+          </button>
+          <span className="text-slate-500">
+            Page <span className="font-semibold text-slate-700">{page + 1}</span> of{' '}
+            <span className="font-semibold text-slate-700">{Math.max(totalPages, 1)}</span>
+          </span>
+          <button
+            type="button"
+            onClick={handleNextPage}
+            disabled={page + 1 >= totalPages}
+            className="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ActivityPage;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import api from '../services/http';
 import { useAppSelector, useAppDispatch } from '../app/hooks';
@@ -9,16 +9,66 @@ import { extractErrorMessage } from '../utils/errors';
 const ProfilePage = () => {
   const dispatch = useAppDispatch();
   const { user } = useAppSelector((state) => state.auth);
-  const [form, setForm] = useState({ fullName: user?.fullName ?? '', password: '' });
+  const [form, setForm] = useState({
+    firstName: user?.firstName ?? '',
+    lastName: user?.lastName ?? '',
+    email: user?.email ?? '',
+    phoneNumber: user?.phoneNumber ?? '',
+    whatsappNumber: user?.whatsappNumber ?? '',
+    facebookUrl: user?.facebookUrl ?? '',
+    linkedinUrl: user?.linkedinUrl ?? '',
+    skypeId: user?.skypeId ?? '',
+    emailSignature: user?.emailSignature ?? '',
+    oldPassword: '',
+    newPassword: '',
+    confirmNewPassword: ''
+  });
   const [error, setError] = useState<string | null>(null);
   const { notify } = useToast();
 
+  useEffect(() => {
+    setForm((prev) => ({
+      ...prev,
+      firstName: user?.firstName ?? '',
+      lastName: user?.lastName ?? '',
+      email: user?.email ?? '',
+      phoneNumber: user?.phoneNumber ?? '',
+      whatsappNumber: user?.whatsappNumber ?? '',
+      facebookUrl: user?.facebookUrl ?? '',
+      linkedinUrl: user?.linkedinUrl ?? '',
+      skypeId: user?.skypeId ?? '',
+      emailSignature: user?.emailSignature ?? ''
+    }));
+  }, [user?.firstName, user?.lastName, user?.email, user?.phoneNumber, user?.whatsappNumber, user?.facebookUrl, user?.linkedinUrl, user?.skypeId, user?.emailSignature]);
+
   const updateProfile = useMutation({
     mutationFn: async () => {
-      await api.put('/profile', form);
+      const oldPassword = form.oldPassword.trim();
+      const newPassword = form.newPassword.trim();
+      const confirmPassword = form.confirmNewPassword.trim();
+      const payload = {
+        firstName: form.firstName.trim(),
+        lastName: form.lastName.trim(),
+        email: form.email.trim(),
+        phoneNumber: form.phoneNumber.trim() || undefined,
+        whatsappNumber: form.whatsappNumber.trim() || undefined,
+        facebookUrl: form.facebookUrl.trim() || undefined,
+        linkedinUrl: form.linkedinUrl.trim() || undefined,
+        skypeId: form.skypeId.trim() || undefined,
+        emailSignature: form.emailSignature.trim() || undefined,
+        oldPassword: oldPassword ? oldPassword : undefined,
+        newPassword: newPassword ? newPassword : undefined,
+        confirmNewPassword: confirmPassword ? confirmPassword : undefined
+      };
+      await api.put('/profile', payload);
     },
     onSuccess: () => {
-      setForm((prev) => ({ ...prev, password: '' }));
+      setForm((prev) => ({
+        ...prev,
+        oldPassword: '',
+        newPassword: '',
+        confirmNewPassword: ''
+      }));
       setError(null);
       dispatch(loadCurrentUser());
       notify({ type: 'success', message: 'Profile updated successfully.' });
@@ -32,56 +82,238 @@ const ProfilePage = () => {
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    if (!form.fullName.trim()) {
-      const message = 'Full name is required.';
+    const trimmedFirst = form.firstName.trim();
+    const trimmedLast = form.lastName.trim();
+    const trimmedEmail = form.email.trim();
+    if (!trimmedFirst) {
+      const message = 'First name is required.';
       setError(message);
       notify({ type: 'error', message });
       return;
     }
-    if (form.password && form.password.length > 0 && form.password.length < 8) {
-      const message = 'Password must be at least 8 characters long.';
+    if (!trimmedLast) {
+      const message = 'Last name is required.';
       setError(message);
       notify({ type: 'error', message });
       return;
     }
+    if (!trimmedEmail) {
+      const message = 'Email is required.';
+      setError(message);
+      notify({ type: 'error', message });
+      return;
+    }
+
+    const wantsPasswordChange = Boolean(
+      form.oldPassword.trim() || form.newPassword.trim() || form.confirmNewPassword.trim()
+    );
+    if (wantsPasswordChange) {
+      if (!form.oldPassword.trim()) {
+        const message = 'Current password is required to change your password.';
+        setError(message);
+        notify({ type: 'error', message });
+        return;
+      }
+      if (form.newPassword.trim().length < 8) {
+        const message = 'New password must be at least 8 characters long.';
+        setError(message);
+        notify({ type: 'error', message });
+        return;
+      }
+      if (form.newPassword !== form.confirmNewPassword) {
+        const message = 'New password confirmation does not match.';
+        setError(message);
+        notify({ type: 'error', message });
+        return;
+      }
+    }
+
     setError(null);
     updateProfile.mutate();
   };
 
   return (
-    <div className="max-w-2xl space-y-6">
-      <h1 className="text-2xl font-semibold text-slate-800">Profile</h1>
-      <form onSubmit={handleSubmit} className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Full name</label>
-            <input
-              type="text"
-              value={form.fullName}
-              onChange={(e) => setForm((prev) => ({ ...prev, fullName: e.target.value }))}
-              required
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-800">Profile</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Manage your personal details, contact preferences, and account security in one place.
+        </p>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-800">Personal information</h2>
+          <p className="mt-1 text-sm text-slate-500">This information is used across the workspace to identify you.</p>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-600">First name</label>
+              <input
+                type="text"
+                value={form.firstName}
+                onChange={(e) => setForm((prev) => ({ ...prev, firstName: e.target.value }))}
+                required
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Last name</label>
+              <input
+                type="text"
+                value={form.lastName}
+                onChange={(e) => setForm((prev) => ({ ...prev, lastName: e.target.value }))}
+                required
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Email</label>
+              <input
+                type="email"
+                value={form.email}
+                onChange={(e) => setForm((prev) => ({ ...prev, email: e.target.value }))}
+                required
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Phone number</label>
+              <input
+                type="tel"
+                value={form.phoneNumber}
+                onChange={(e) => setForm((prev) => ({ ...prev, phoneNumber: e.target.value }))}
+                placeholder="Optional"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">WhatsApp number</label>
+              <input
+                type="tel"
+                value={form.whatsappNumber}
+                onChange={(e) => setForm((prev) => ({ ...prev, whatsappNumber: e.target.value }))}
+                placeholder="Optional"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Skype</label>
+              <input
+                type="text"
+                value={form.skypeId}
+                onChange={(e) => setForm((prev) => ({ ...prev, skypeId: e.target.value }))}
+                placeholder="Optional"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">LinkedIn</label>
+              <input
+                type="url"
+                value={form.linkedinUrl}
+                onChange={(e) => setForm((prev) => ({ ...prev, linkedinUrl: e.target.value }))}
+                placeholder="https://linkedin.com/in/username"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Facebook</label>
+              <input
+                type="url"
+                value={form.facebookUrl}
+                onChange={(e) => setForm((prev) => ({ ...prev, facebookUrl: e.target.value }))}
+                placeholder="https://facebook.com/username"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+          </div>
+          <div className="mt-4">
+            <label className="block text-sm font-medium text-slate-600">Email signature</label>
+            <textarea
+              value={form.emailSignature}
+              onChange={(e) => setForm((prev) => ({ ...prev, emailSignature: e.target.value }))}
+              placeholder="Include closing, contact info, or compliance messages"
+              rows={4}
               className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
             />
           </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Password</label>
-            <input
-              type="password"
-              value={form.password}
-              onChange={(e) => setForm((prev) => ({ ...prev, password: e.target.value }))}
-              placeholder="Leave blank to keep current password"
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
-            />
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-800">Change password</h2>
+              <p className="mt-1 text-sm text-slate-500">
+                Enter your current password to set a new one. Passwords must be at least 8 characters long.
+              </p>
+            </div>
           </div>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Current password</label>
+              <input
+                type="password"
+                value={form.oldPassword}
+                onChange={(e) => setForm((prev) => ({ ...prev, oldPassword: e.target.value }))}
+                placeholder="••••••••"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">New password</label>
+              <input
+                type="password"
+                value={form.newPassword}
+                onChange={(e) => setForm((prev) => ({ ...prev, newPassword: e.target.value }))}
+                placeholder="At least 8 characters"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Confirm new password</label>
+              <input
+                type="password"
+                value={form.confirmNewPassword}
+                onChange={(e) => setForm((prev) => ({ ...prev, confirmNewPassword: e.target.value }))}
+                placeholder="Re-enter new password"
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              />
+            </div>
+          </div>
+        </section>
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            className="rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600"
+            onClick={() => {
+              setForm({
+                firstName: user?.firstName ?? '',
+                lastName: user?.lastName ?? '',
+                email: user?.email ?? '',
+                phoneNumber: user?.phoneNumber ?? '',
+                whatsappNumber: user?.whatsappNumber ?? '',
+                facebookUrl: user?.facebookUrl ?? '',
+                linkedinUrl: user?.linkedinUrl ?? '',
+                skypeId: user?.skypeId ?? '',
+                emailSignature: user?.emailSignature ?? '',
+                oldPassword: '',
+                newPassword: '',
+                confirmNewPassword: ''
+              });
+              setError(null);
+            }}
+          >
+            Reset
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
+            disabled={updateProfile.isPending}
+          >
+            {updateProfile.isPending ? 'Saving…' : 'Save changes'}
+          </button>
         </div>
-        <button
-          type="submit"
-          className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white"
-          disabled={updateProfile.isPending}
-        >
-          {updateProfile.isPending ? 'Saving...' : 'Save changes'}
-        </button>
-        {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
       </form>
     </div>
   );

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -8,7 +8,7 @@ const SignupPage = () => {
   const dispatch = useAppDispatch();
   const applicationName = useAppSelector(selectApplicationName);
   const navigate = useNavigate();
-  const [form, setForm] = useState({ email: '', password: '', fullName: '' });
+  const [form, setForm] = useState({ email: '', password: '', firstName: '', lastName: '' });
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -26,15 +26,27 @@ const SignupPage = () => {
           Sign up to explore {applicationName || 'the dashboard'}.
         </p>
         <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
-          <div>
-            <label className="block text-sm font-medium text-slate-600">Full name</label>
-            <input
-              type="text"
-              value={form.fullName}
-              onChange={(e) => setForm((prev) => ({ ...prev, fullName: e.target.value }))}
-              required
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
-            />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-600">First name</label>
+              <input
+                type="text"
+                value={form.firstName}
+                onChange={(e) => setForm((prev) => ({ ...prev, firstName: e.target.value }))}
+                required
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-600">Last name</label>
+              <input
+                type="text"
+                value={form.lastName}
+                onChange={(e) => setForm((prev) => ({ ...prev, lastName: e.target.value }))}
+                required
+                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
+              />
+            </div>
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-600">Email</label>
@@ -53,8 +65,10 @@ const SignupPage = () => {
               value={form.password}
               onChange={(e) => setForm((prev) => ({ ...prev, password: e.target.value }))}
               required
+              minLength={8}
               className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 focus:border-primary focus:outline-none"
             />
+            <p className="mt-1 text-xs text-slate-500">Passwords must contain at least 8 characters.</p>
           </div>
           <button
             type="submit"

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -52,20 +52,34 @@ type DetailTab = 'profile' | 'access';
 type UserSortField = 'name' | 'email' | 'status' | 'audience' | 'groups';
 
 type UserFormState = {
-  fullName: string;
+  firstName: string;
+  lastName: string;
   email: string;
   password: string;
   active: boolean;
+  phoneNumber: string;
+  whatsappNumber: string;
+  facebookUrl: string;
+  linkedinUrl: string;
+  skypeId: string;
+  emailSignature: string;
   roleIds: number[];
   directPermissions: string[];
   revokedPermissions: string[];
 };
 
 const emptyForm: UserFormState = {
-  fullName: '',
+  firstName: '',
+  lastName: '',
   email: '',
   password: '',
   active: true,
+  phoneNumber: '',
+  whatsappNumber: '',
+  facebookUrl: '',
+  linkedinUrl: '',
+  skypeId: '',
+  emailSignature: '',
   roleIds: [],
   directPermissions: [],
   revokedPermissions: []
@@ -233,10 +247,17 @@ const UsersPage = () => {
         .map(normalizePermissionKey)
         .filter((permissionKey) => roleDerivedPermissions.has(permissionKey));
       setForm({
-        fullName: detail.fullName,
+        firstName: detail.firstName ?? '',
+        lastName: detail.lastName ?? '',
         email: detail.email,
         password: '',
         active: detail.active,
+        phoneNumber: detail.phoneNumber ?? '',
+        whatsappNumber: detail.whatsappNumber ?? '',
+        facebookUrl: detail.facebookUrl ?? '',
+        linkedinUrl: detail.linkedinUrl ?? '',
+        skypeId: detail.skypeId ?? '',
+        emailSignature: detail.emailSignature ?? '',
         roleIds: assignedRoleIds,
         directPermissions: sanitizedDirect,
         revokedPermissions: sanitizedRevoked
@@ -258,10 +279,17 @@ const UsersPage = () => {
         throw new Error('Password must be at least 8 characters long.');
       }
       const { data } = await api.post<User>('/users', {
-        email: form.email,
-        fullName: form.fullName,
+        email: form.email.trim(),
+        firstName: form.firstName.trim(),
+        lastName: form.lastName.trim(),
         password: trimmedPassword,
         active: form.active,
+        phoneNumber: form.phoneNumber.trim() || undefined,
+        whatsappNumber: form.whatsappNumber.trim() || undefined,
+        facebookUrl: form.facebookUrl.trim() || undefined,
+        linkedinUrl: form.linkedinUrl.trim() || undefined,
+        skypeId: form.skypeId.trim() || undefined,
+        emailSignature: form.emailSignature.trim() || undefined,
         roleIds: form.roleIds,
         permissionKeys: form.directPermissions,
         revokedPermissionKeys: form.revokedPermissions
@@ -275,10 +303,17 @@ const UsersPage = () => {
       setPanelMode('detail');
       setActiveTab('profile');
       setForm({
-        fullName: data.fullName,
+        firstName: data.firstName ?? '',
+        lastName: data.lastName ?? '',
         email: data.email,
         password: '',
         active: data.active,
+        phoneNumber: data.phoneNumber ?? '',
+        whatsappNumber: data.whatsappNumber ?? '',
+        facebookUrl: data.facebookUrl ?? '',
+        linkedinUrl: data.linkedinUrl ?? '',
+        skypeId: data.skypeId ?? '',
+        emailSignature: data.emailSignature ?? '',
         roleIds: data.roles
           .map((roleKey) => roleIdByKey.get(roleKey.toUpperCase()))
           .filter((value): value is number => typeof value === 'number'),
@@ -304,9 +339,16 @@ const UsersPage = () => {
         throw new Error('Password must be at least 8 characters long.');
       }
       const { data } = await api.put<User>(`/users/${selectedUserId}`, {
-        email: form.email,
-        fullName: form.fullName,
+        email: form.email.trim(),
+        firstName: form.firstName.trim(),
+        lastName: form.lastName.trim(),
         active: form.active,
+        phoneNumber: form.phoneNumber.trim() || undefined,
+        whatsappNumber: form.whatsappNumber.trim() || undefined,
+        facebookUrl: form.facebookUrl.trim() || undefined,
+        linkedinUrl: form.linkedinUrl.trim() || undefined,
+        skypeId: form.skypeId.trim() || undefined,
+        emailSignature: form.emailSignature.trim() || undefined,
         password: trimmedPassword || undefined,
         roleIds: form.roleIds,
         permissionKeys: form.directPermissions,
@@ -321,10 +363,17 @@ const UsersPage = () => {
       notify({ type: 'success', message: 'User updated successfully.' });
       invalidateUsers();
       setForm({
-        fullName: data.fullName,
+        firstName: data.firstName ?? '',
+        lastName: data.lastName ?? '',
         email: data.email,
         password: '',
         active: data.active,
+        phoneNumber: data.phoneNumber ?? '',
+        whatsappNumber: data.whatsappNumber ?? '',
+        facebookUrl: data.facebookUrl ?? '',
+        linkedinUrl: data.linkedinUrl ?? '',
+        skypeId: data.skypeId ?? '',
+        emailSignature: data.emailSignature ?? '',
         roleIds: data.roles
           .map((roleKey) => roleIdByKey.get(roleKey.toUpperCase()))
           .filter((value): value is number => typeof value === 'number'),
@@ -937,16 +986,26 @@ const UsersPage = () => {
   );
 
   const renderProfileTab = (isEditable: boolean, isCreate: boolean) => (
-    <div className="space-y-5">
+    <div className="space-y-6">
       <div className="grid gap-4 md:grid-cols-2">
         <div>
-          <label className="block text-sm font-medium text-slate-600">Full name</label>
+          <label className="block text-sm font-medium text-slate-600">First name</label>
           <input
             type="text"
-            value={form.fullName}
-            onChange={(event) => handleFieldChange('fullName', event.target.value)}
+            value={form.firstName}
+            onChange={(event) => handleFieldChange('firstName', event.target.value)}
             required
-            minLength={2}
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Last name</label>
+          <input
+            type="text"
+            value={form.lastName}
+            onChange={(event) => handleFieldChange('lastName', event.target.value)}
+            required
             disabled={!isEditable}
             className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
           />
@@ -963,20 +1022,6 @@ const UsersPage = () => {
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-slate-600">Password</label>
-          <input
-            type="password"
-            value={form.password}
-            onChange={(event) => handleFieldChange('password', event.target.value)}
-            required={isCreate}
-            minLength={isCreate ? 8 : 0}
-            placeholder={isCreate ? 'At least 8 characters' : 'Leave blank to keep the current password'}
-            disabled={!isEditable}
-            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
-          />
-          <p className="mt-1 text-xs text-slate-500">Passwords must contain at least 8 characters.</p>
-        </div>
-        <div>
           <label className="block text-sm font-medium text-slate-600">Status</label>
           <select
             value={form.active ? 'true' : 'false'}
@@ -988,6 +1033,86 @@ const UsersPage = () => {
             <option value="false">Inactive</option>
           </select>
         </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Phone number</label>
+          <input
+            type="tel"
+            value={form.phoneNumber}
+            onChange={(event) => handleFieldChange('phoneNumber', event.target.value)}
+            placeholder="Optional"
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">WhatsApp number</label>
+          <input
+            type="tel"
+            value={form.whatsappNumber}
+            onChange={(event) => handleFieldChange('whatsappNumber', event.target.value)}
+            placeholder="Optional"
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Skype</label>
+          <input
+            type="text"
+            value={form.skypeId}
+            onChange={(event) => handleFieldChange('skypeId', event.target.value)}
+            placeholder="Optional"
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">LinkedIn</label>
+          <input
+            type="url"
+            value={form.linkedinUrl}
+            onChange={(event) => handleFieldChange('linkedinUrl', event.target.value)}
+            placeholder="https://linkedin.com/in/username"
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-600">Facebook</label>
+          <input
+            type="url"
+            value={form.facebookUrl}
+            onChange={(event) => handleFieldChange('facebookUrl', event.target.value)}
+            placeholder="https://facebook.com/username"
+            disabled={!isEditable}
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-600">Email signature</label>
+        <textarea
+          value={form.emailSignature}
+          onChange={(event) => handleFieldChange('emailSignature', event.target.value)}
+          placeholder="Optional signature shown on outbound email"
+          disabled={!isEditable}
+          rows={4}
+          className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-600">Password</label>
+        <input
+          type="password"
+          value={form.password}
+          onChange={(event) => handleFieldChange('password', event.target.value)}
+          required={isCreate}
+          minLength={isCreate ? 8 : 0}
+          placeholder={isCreate ? 'At least 8 characters' : 'Leave blank to keep the current password'}
+          disabled={!isEditable}
+          className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none disabled:bg-slate-100 disabled:text-slate-500"
+        />
+        <p className="mt-1 text-xs text-slate-500">Passwords must contain at least 8 characters.</p>
       </div>
       <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
         Customer accounts are represented as users holding the <span className="font-semibold">CUSTOMER</span> role. Assign or
@@ -1351,10 +1476,17 @@ const UsersPage = () => {
                 onClick={() => {
                   const detail = selectedUserQuery.data;
                   setForm({
-                    fullName: detail.fullName,
+                    firstName: detail.firstName ?? '',
+                    lastName: detail.lastName ?? '',
                     email: detail.email,
                     password: '',
                     active: detail.active,
+                    phoneNumber: detail.phoneNumber ?? '',
+                    whatsappNumber: detail.whatsappNumber ?? '',
+                    facebookUrl: detail.facebookUrl ?? '',
+                    linkedinUrl: detail.linkedinUrl ?? '',
+                    skypeId: detail.skypeId ?? '',
+                    emailSignature: detail.emailSignature ?? '',
                     roleIds: detail.roles
                       .map((roleKey) => roleIdByKey.get(roleKey.toUpperCase()))
                       .filter((value): value is number => typeof value === 'number'),

--- a/frontend/src/routes/ProtectedRoute.tsx
+++ b/frontend/src/routes/ProtectedRoute.tsx
@@ -2,11 +2,18 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAppSelector } from '../app/hooks';
 
 const ProtectedRoute = () => {
-  const { accessToken } = useAppSelector((state) => state.auth);
-  if (!accessToken) {
-    return <Navigate to="/login" replace />;
+  const { accessToken, refreshToken } = useAppSelector((state) => state.auth);
+  if (accessToken) {
+    return <Outlet />;
   }
-  return <Outlet />;
+  if (refreshToken) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-sm text-slate-500">
+        Restoring your session…
+      </div>
+    );
+  }
+  return <Navigate to="/login" replace />;
 };
 
 export default ProtectedRoute;

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -13,6 +13,14 @@ export interface UserSummary {
   id: number;
   email: string;
   fullName: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber?: string | null;
+  whatsappNumber?: string | null;
+  facebookUrl?: string | null;
+  linkedinUrl?: string | null;
+  skypeId?: string | null;
+  emailSignature?: string | null;
   active: boolean;
   roles: string[];
   permissions: PermissionKey[];

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -12,6 +12,14 @@ export interface User extends Record<string, unknown> {
   id: number;
   email: string;
   fullName: string;
+  firstName: string;
+  lastName: string;
+  phoneNumber?: string | null;
+  whatsappNumber?: string | null;
+  facebookUrl?: string | null;
+  linkedinUrl?: string | null;
+  skypeId?: string | null;
+  emailSignature?: string | null;
   active: boolean;
   roles: string[];
   permissions: PermissionKey[];
@@ -68,4 +76,34 @@ export interface Invoice {
   tax: number;
   total: number;
   items: InvoiceItem[];
+}
+
+export interface ActivityLogEntry {
+  id: number;
+  occurredAt: string;
+  userId?: number | null;
+  userName: string;
+  userRole?: string | null;
+  department?: string | null;
+  module?: string | null;
+  activityType: string;
+  description?: string | null;
+  status?: string | null;
+  ipAddress?: string | null;
+  device?: string | null;
+}
+
+export interface ActivityLogDetail extends ActivityLogEntry {
+  context?: Record<string, unknown> | null;
+  rawContext?: string | null;
+}
+
+export interface ActivityFilterOptions {
+  activityTypes: string[];
+  modules: string[];
+  statuses: string[];
+  roles: string[];
+  departments: string[];
+  ipAddresses: string[];
+  devices: string[];
 }

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -50,5 +50,6 @@ export const TAB_RULES: Record<string, PermissionKey[]> = {
     'INVOICE_UPDATE',
     'INVOICE_DELETE'
   ],
+  Activity: ['ACTIVITY_VIEW'],
   Settings: ['SETTINGS_VIEW']
 };


### PR DESCRIPTION
## Summary
- add profile metadata columns and password-change validation across user domain models, DTOs, services, and migrations
- expose the new profile fields throughout signup, profile, and user management screens with refreshed sidebar profile access
- persist refresh tokens in auth state and gated routes so page reloads restore sessions without forcing logout

## Testing
- npm --prefix frontend run build
- mvn -f backend/pom.xml test *(fails: Maven Central returns HTTP 403 while resolving Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dbc4cd2c8323b3b1ec8d98907f73