### PR TITLE
Add gallery module for file management

### DIFF
--- a/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
+++ b/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
@@ -1,0 +1,113 @@
+package com.example.rbac.gallery.controller;
+
+import com.example.rbac.common.pagination.PageResponse;
+import com.example.rbac.gallery.dto.*;
+import com.example.rbac.gallery.service.GalleryFileContent;
+import com.example.rbac.gallery.service.GalleryService;
+import com.example.rbac.users.model.UserPrincipal;
+import jakarta.validation.Valid;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/gallery")
+public class GalleryController {
+
+    private final GalleryService galleryService;
+
+    public GalleryController(GalleryService galleryService) {
+        this.galleryService = galleryService;
+    }
+
+    @GetMapping("/files")
+    @PreAuthorize("hasAnyAuthority('GALLERY_VIEW_ALL','GALLERY_VIEW_OWN')")
+    public PageResponse<GalleryFileDto> listFiles(@RequestParam(name = "page", defaultValue = "0") int page,
+                                                  @RequestParam(name = "size", defaultValue = "20") int size,
+                                                  @RequestParam(name = "sort", required = false) String sort,
+                                                  @RequestParam(name = "direction", required = false) String direction,
+                                                  @RequestParam(name = "folderId", required = false) Long folderId,
+                                                  @RequestParam(name = "uploaderId", required = false) Long uploaderId,
+                                                  @RequestParam(name = "uploader", required = false) String uploaderEmail,
+                                                  @RequestParam(name = "search", required = false) String search,
+                                                  @AuthenticationPrincipal UserPrincipal principal) {
+        return galleryService.list(page, size, sort, direction, folderId, uploaderId, uploaderEmail, search, principal);
+    }
+
+    @PostMapping("/files")
+    @PreAuthorize("hasAuthority('GALLERY_CREATE')")
+    public List<GalleryFileDto> uploadFiles(@RequestParam(name = "folderId", required = false) Long folderId,
+                                            @RequestParam("files") List<MultipartFile> files,
+                                            @AuthenticationPrincipal UserPrincipal principal) {
+        return galleryService.upload(folderId, files, principal);
+    }
+
+    @PatchMapping("/files/{id}")
+    @PreAuthorize("hasAuthority('GALLERY_EDIT_ALL')")
+    public GalleryFileDto updateFile(@PathVariable("id") Long id,
+                                     @Valid @RequestBody GalleryFileUpdateRequest request) {
+        return galleryService.updateFile(id, request);
+    }
+
+    @DeleteMapping("/files/{id}")
+    @PreAuthorize("hasAnyAuthority('GALLERY_DELETE_ALL','GALLERY_DELETE_OWN')")
+    public void deleteFile(@PathVariable("id") Long id,
+                           @AuthenticationPrincipal UserPrincipal principal) {
+        galleryService.delete(id, principal);
+    }
+
+    @PostMapping("/files/bulk-delete")
+    @PreAuthorize("hasAnyAuthority('GALLERY_DELETE_ALL','GALLERY_DELETE_OWN')")
+    public void bulkDelete(@Valid @RequestBody GalleryBulkDeleteRequest request,
+                           @AuthenticationPrincipal UserPrincipal principal) {
+        galleryService.deleteBulk(request, principal);
+    }
+
+    @GetMapping("/files/{id}/content")
+    @PreAuthorize("hasAnyAuthority('GALLERY_VIEW_ALL','GALLERY_VIEW_OWN')")
+    public ResponseEntity<Resource> downloadFile(@PathVariable("id") Long id,
+                                                  @AuthenticationPrincipal UserPrincipal principal) {
+        GalleryFileContent content = galleryService.loadContent(id, principal);
+        String filename = encodeFilename(content.filename());
+        MediaType mediaType = content.mimeType() != null ? MediaType.parseMediaType(content.mimeType()) : MediaType.APPLICATION_OCTET_STREAM;
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"")
+                .body(content.resource());
+    }
+
+    @GetMapping("/folders")
+    @PreAuthorize("hasAnyAuthority('GALLERY_VIEW_ALL','GALLERY_VIEW_OWN','GALLERY_CREATE','GALLERY_EDIT_ALL')")
+    public List<GalleryFolderDto> listFolders() {
+        return galleryService.listFolders();
+    }
+
+    @PostMapping("/folders")
+    @PreAuthorize("hasAuthority('GALLERY_CREATE')")
+    public GalleryFolderDto createFolder(@Valid @RequestBody GalleryFolderCreateRequest request) {
+        return galleryService.createFolder(request);
+    }
+
+    @PatchMapping("/folders/{id}")
+    @PreAuthorize("hasAuthority('GALLERY_EDIT_ALL')")
+    public GalleryFolderDto renameFolder(@PathVariable("id") Long id,
+                                         @Valid @RequestBody GalleryFolderRenameRequest request) {
+        return galleryService.renameFolder(id, request);
+    }
+
+    private String encodeFilename(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return "file";
+        }
+        return URLEncoder.encode(filename, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryBulkDeleteRequest.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryBulkDeleteRequest.java
@@ -1,0 +1,19 @@
+package com.example.rbac.gallery.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public class GalleryBulkDeleteRequest {
+
+    @NotEmpty
+    private List<Long> ids;
+
+    public List<Long> getIds() {
+        return ids;
+    }
+
+    public void setIds(List<Long> ids) {
+        this.ids = ids;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFileDto.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFileDto.java
@@ -1,0 +1,115 @@
+package com.example.rbac.gallery.dto;
+
+import java.time.Instant;
+
+public class GalleryFileDto {
+
+    private Long id;
+    private String displayName;
+    private String originalFilename;
+    private String extension;
+    private String mimeType;
+    private long sizeBytes;
+    private Instant uploadedAt;
+    private Long uploadedById;
+    private String uploadedByName;
+    private String uploadedByEmail;
+    private Long folderId;
+    private String folderPath;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public void setOriginalFilename(String originalFilename) {
+        this.originalFilename = originalFilename;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+        this.sizeBytes = sizeBytes;
+    }
+
+    public Instant getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public void setUploadedAt(Instant uploadedAt) {
+        this.uploadedAt = uploadedAt;
+    }
+
+    public Long getUploadedById() {
+        return uploadedById;
+    }
+
+    public void setUploadedById(Long uploadedById) {
+        this.uploadedById = uploadedById;
+    }
+
+    public String getUploadedByName() {
+        return uploadedByName;
+    }
+
+    public void setUploadedByName(String uploadedByName) {
+        this.uploadedByName = uploadedByName;
+    }
+
+    public String getUploadedByEmail() {
+        return uploadedByEmail;
+    }
+
+    public void setUploadedByEmail(String uploadedByEmail) {
+        this.uploadedByEmail = uploadedByEmail;
+    }
+
+    public Long getFolderId() {
+        return folderId;
+    }
+
+    public void setFolderId(Long folderId) {
+        this.folderId = folderId;
+    }
+
+    public String getFolderPath() {
+        return folderPath;
+    }
+
+    public void setFolderPath(String folderPath) {
+        this.folderPath = folderPath;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFileUpdateRequest.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFileUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.example.rbac.gallery.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class GalleryFileUpdateRequest {
+
+    @NotBlank
+    @Size(max = 255)
+    private String displayName;
+
+    private Long targetFolderId;
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public Long getTargetFolderId() {
+        return targetFolderId;
+    }
+
+    public void setTargetFolderId(Long targetFolderId) {
+        this.targetFolderId = targetFolderId;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderCreateRequest.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderCreateRequest.java
@@ -1,0 +1,29 @@
+package com.example.rbac.gallery.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class GalleryFolderCreateRequest {
+
+    @NotBlank
+    @Size(max = 150)
+    private String name;
+
+    private Long parentId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderDto.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderDto.java
@@ -1,0 +1,61 @@
+package com.example.rbac.gallery.dto;
+
+public class GalleryFolderDto {
+
+    private Long id;
+    private String name;
+    private String path;
+    private Long parentId;
+    private boolean root;
+
+    public GalleryFolderDto() {
+    }
+
+    public GalleryFolderDto(Long id, String name, String path, Long parentId, boolean root) {
+        this.id = id;
+        this.name = name;
+        this.path = path;
+        this.parentId = parentId;
+        this.root = root;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public void setParentId(Long parentId) {
+        this.parentId = parentId;
+    }
+
+    public boolean isRoot() {
+        return root;
+    }
+
+    public void setRoot(boolean root) {
+        this.root = root;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderRenameRequest.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderRenameRequest.java
@@ -1,0 +1,19 @@
+package com.example.rbac.gallery.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class GalleryFolderRenameRequest {
+
+    @NotBlank
+    @Size(max = 150)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/model/GalleryFile.java
+++ b/backend/src/main/java/com/example/rbac/gallery/model/GalleryFile.java
@@ -1,0 +1,147 @@
+package com.example.rbac.gallery.model;
+
+import com.example.rbac.users.model.User;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "gallery_files")
+public class GalleryFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id")
+    private GalleryFolder folder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uploader_id", nullable = false)
+    private User uploader;
+
+    @Column(name = "display_name", nullable = false, length = 255)
+    private String displayName;
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    private String originalFilename;
+
+    @Column(nullable = false, length = 20)
+    private String extension;
+
+    @Column(name = "mime_type", length = 100)
+    private String mimeType;
+
+    @Column(name = "size_bytes", nullable = false)
+    private long sizeBytes;
+
+    @Column(name = "storage_key", nullable = false, unique = true, length = 500)
+    private String storageKey;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public GalleryFolder getFolder() {
+        return folder;
+    }
+
+    public void setFolder(GalleryFolder folder) {
+        this.folder = folder;
+    }
+
+    public User getUploader() {
+        return uploader;
+    }
+
+    public void setUploader(User uploader) {
+        this.uploader = uploader;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public void setOriginalFilename(String originalFilename) {
+        this.originalFilename = originalFilename;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public void setSizeBytes(long sizeBytes) {
+        this.sizeBytes = sizeBytes;
+    }
+
+    public String getStorageKey() {
+        return storageKey;
+    }
+
+    public void setStorageKey(String storageKey) {
+        this.storageKey = storageKey;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/model/GalleryFolder.java
+++ b/backend/src/main/java/com/example/rbac/gallery/model/GalleryFolder.java
@@ -1,0 +1,137 @@
+package com.example.rbac.gallery.model;
+
+import jakarta.persistence.*;
+
+import java.text.Normalizer;
+import java.time.Instant;
+import java.util.Locale;
+
+@Entity
+@Table(name = "gallery_folders")
+public class GalleryFolder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(nullable = false, length = 160)
+    private String slug;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String path;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private GalleryFolder parent;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+        refreshComputedFields();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+        refreshComputedFields();
+    }
+
+    public void refreshComputedFields() {
+        name = name == null ? null : name.trim();
+        if (name == null || name.isEmpty()) {
+            throw new IllegalStateException("Folder name cannot be blank");
+        }
+        slug = buildSlug(name);
+        path = buildPath();
+    }
+
+    private String buildSlug(String source) {
+        String normalized = Normalizer.normalize(source, Normalizer.Form.NFD)
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        String cleaned = normalized.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9\\s-_]", "");
+        cleaned = cleaned.trim().replaceAll("[\\s-_]+", "-");
+        if (cleaned.isEmpty()) {
+            cleaned = "folder" + Long.toHexString(System.nanoTime());
+        }
+        return cleaned.length() > 150 ? cleaned.substring(0, 150) : cleaned;
+    }
+
+    private String buildPath() {
+        String parentPath = parent != null ? parent.getPath() : "/";
+        if (parentPath == null || parentPath.isBlank() || "/".equals(parentPath)) {
+            return "/" + slug;
+        }
+        if (parentPath.endsWith("/")) {
+            return parentPath + slug;
+        }
+        return parentPath + "/" + slug;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public GalleryFolder getParent() {
+        return parent;
+    }
+
+    public void setParent(GalleryFolder parent) {
+        this.parent = parent;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFileRepository.java
+++ b/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFileRepository.java
@@ -1,0 +1,8 @@
+package com.example.rbac.gallery.repository;
+
+import com.example.rbac.gallery.model.GalleryFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface GalleryFileRepository extends JpaRepository<GalleryFile, Long>, JpaSpecificationExecutor<GalleryFile> {
+}

--- a/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFolderRepository.java
+++ b/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFolderRepository.java
@@ -1,0 +1,16 @@
+package com.example.rbac.gallery.repository;
+
+import com.example.rbac.gallery.model.GalleryFolder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GalleryFolderRepository extends JpaRepository<GalleryFolder, Long> {
+
+    Optional<GalleryFolder> findByPath(String path);
+
+    List<GalleryFolder> findByParentId(Long parentId);
+
+    List<GalleryFolder> findByParentIsNull();
+}

--- a/backend/src/main/java/com/example/rbac/gallery/service/GalleryFileContent.java
+++ b/backend/src/main/java/com/example/rbac/gallery/service/GalleryFileContent.java
@@ -1,0 +1,6 @@
+package com.example.rbac.gallery.service;
+
+import org.springframework.core.io.Resource;
+
+public record GalleryFileContent(Resource resource, String mimeType, String filename) {
+}

--- a/backend/src/main/java/com/example/rbac/gallery/service/GalleryFileSpecifications.java
+++ b/backend/src/main/java/com/example/rbac/gallery/service/GalleryFileSpecifications.java
@@ -1,0 +1,55 @@
+package com.example.rbac.gallery.service;
+
+import com.example.rbac.gallery.model.GalleryFile;
+import jakarta.persistence.criteria.JoinType;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class GalleryFileSpecifications {
+
+    private GalleryFileSpecifications() {
+    }
+
+    public static Specification<GalleryFile> belongsToFolder(Long folderId) {
+        if (folderId == null) {
+            return null;
+        }
+        return (root, query, builder) -> builder.equal(root.join("folder", JoinType.LEFT).get("id"), folderId);
+    }
+
+    public static Specification<GalleryFile> uploadedBy(Long uploaderId) {
+        if (uploaderId == null) {
+            return null;
+        }
+        return (root, query, builder) -> builder.equal(root.join("uploader", JoinType.INNER).get("id"), uploaderId);
+    }
+
+    public static Specification<GalleryFile> uploaderEmailContains(String uploaderEmail) {
+        if (uploaderEmail == null || uploaderEmail.isBlank()) {
+            return null;
+        }
+        String likeValue = "%" + uploaderEmail.trim().toLowerCase() + "%";
+        return (root, query, builder) -> builder.like(builder.lower(root.join("uploader", JoinType.INNER).get("email")), likeValue);
+    }
+
+    public static Specification<GalleryFile> search(String term) {
+        if (term == null || term.isBlank()) {
+            return null;
+        }
+        String likeValue = "%" + term.trim().toLowerCase() + "%";
+        return (root, query, builder) -> builder.or(
+                builder.like(builder.lower(root.get("displayName")), likeValue),
+                builder.like(builder.lower(root.get("originalFilename")), likeValue),
+                builder.like(builder.lower(root.get("extension")), likeValue)
+        );
+    }
+
+    public static Specification<GalleryFile> and(Specification<GalleryFile> left, Specification<GalleryFile> right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+        return left.and(right);
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/service/GalleryService.java
+++ b/backend/src/main/java/com/example/rbac/gallery/service/GalleryService.java
@@ -1,0 +1,389 @@
+package com.example.rbac.gallery.service;
+
+import com.example.rbac.activity.service.ActivityRecorder;
+import com.example.rbac.common.exception.ApiException;
+import com.example.rbac.common.pagination.PageResponse;
+import com.example.rbac.gallery.dto.*;
+import com.example.rbac.gallery.model.GalleryFile;
+import com.example.rbac.gallery.model.GalleryFolder;
+import com.example.rbac.gallery.repository.GalleryFileRepository;
+import com.example.rbac.gallery.repository.GalleryFolderRepository;
+import com.example.rbac.users.model.User;
+import com.example.rbac.users.model.UserPrincipal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.*;
+
+@Service
+public class GalleryService {
+
+    private static final String MODULE_NAME = "Gallery";
+
+    private final GalleryFileRepository fileRepository;
+    private final GalleryFolderRepository folderRepository;
+    private final GallerySettingsService settingsService;
+    private final GalleryStorageService storageService;
+    private final ActivityRecorder activityRecorder;
+
+    public GalleryService(GalleryFileRepository fileRepository,
+                          GalleryFolderRepository folderRepository,
+                          GallerySettingsService settingsService,
+                          GalleryStorageService storageService,
+                          ActivityRecorder activityRecorder) {
+        this.fileRepository = fileRepository;
+        this.folderRepository = folderRepository;
+        this.settingsService = settingsService;
+        this.storageService = storageService;
+        this.activityRecorder = activityRecorder;
+    }
+
+    public PageResponse<GalleryFileDto> list(int page,
+                                             int size,
+                                             String sort,
+                                             String direction,
+                                             Long folderId,
+                                             Long uploaderId,
+                                             String uploaderEmail,
+                                             String search,
+                                             UserPrincipal principal) {
+        boolean canViewAll = hasAuthority(principal, "GALLERY_VIEW_ALL");
+        Long currentUserId = resolveUserId(principal);
+
+        Specification<GalleryFile> specification = Specification.where(null);
+        specification = GalleryFileSpecifications.and(specification, GalleryFileSpecifications.belongsToFolder(folderId));
+        specification = GalleryFileSpecifications.and(specification, GalleryFileSpecifications.search(search));
+
+        if (uploaderId != null && canViewAll) {
+            specification = GalleryFileSpecifications.and(specification, GalleryFileSpecifications.uploadedBy(uploaderId));
+        }
+        if (uploaderEmail != null && canViewAll) {
+            specification = GalleryFileSpecifications.and(specification, GalleryFileSpecifications.uploaderEmailContains(uploaderEmail));
+        }
+        if (!canViewAll && currentUserId != null) {
+            specification = GalleryFileSpecifications.and(specification, GalleryFileSpecifications.uploadedBy(currentUserId));
+        }
+
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.max(size, 1), resolveSort(sort, direction));
+        Page<GalleryFileDto> result = fileRepository.findAll(specification, pageable).map(this::toDto);
+        return PageResponse.from(result);
+    }
+
+    @Transactional
+    public List<GalleryFileDto> upload(Long folderId, List<MultipartFile> files, UserPrincipal principal) {
+        if (files == null || files.isEmpty()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "No files provided for upload");
+        }
+        User uploader = resolveUser(principal);
+        GalleryFolder folder = resolveFolder(folderId);
+        List<String> allowedExtensions = settingsService.resolveAllowedExtensions();
+        List<GalleryFileDto> uploaded = new ArrayList<>();
+        List<Long> fileIds = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            GalleryFile entity = storeFile(folder, uploader, file, allowedExtensions);
+            uploaded.add(toDto(entity));
+            fileIds.add(entity.getId());
+        }
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("fileIds", fileIds);
+        if (folder != null) {
+            context.put("folderId", folder.getId());
+            context.put("folderPath", folder.getPath());
+        }
+        activityRecorder.record(MODULE_NAME, "UPLOAD", "Uploaded " + uploaded.size() + " file(s)", "SUCCESS", context);
+        return uploaded;
+    }
+
+    @Transactional
+    public GalleryFileDto updateFile(Long id, GalleryFileUpdateRequest request) {
+        GalleryFile file = fileRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "File not found"));
+        String displayName = request.getDisplayName().trim();
+        GalleryFolder targetFolder = resolveFolder(request.getTargetFolderId());
+        boolean changed = false;
+
+        if (!displayName.equals(file.getDisplayName())) {
+            file.setDisplayName(displayName);
+            changed = true;
+        }
+
+        Long currentFolderId = file.getFolder() != null ? file.getFolder().getId() : null;
+        Long targetFolderId = targetFolder != null ? targetFolder.getId() : null;
+        if (!Objects.equals(currentFolderId, targetFolderId)) {
+            file.setFolder(targetFolder);
+            changed = true;
+        }
+
+        if (!changed) {
+            return toDto(file);
+        }
+
+        GalleryFile saved = fileRepository.save(file);
+        activityRecorder.record(MODULE_NAME, "UPDATE", "Updated file " + saved.getDisplayName(), "SUCCESS", buildFileContext(saved));
+        return toDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id, UserPrincipal principal) {
+        GalleryFile file = fileRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "File not found"));
+        enforceDeletePermission(file, principal);
+        fileRepository.delete(file);
+        storageService.delete(file.getStorageKey());
+        activityRecorder.record(MODULE_NAME, "DELETE", "Deleted file " + file.getDisplayName(), "SUCCESS", buildFileContext(file));
+    }
+
+    @Transactional
+    public void deleteBulk(GalleryBulkDeleteRequest request, UserPrincipal principal) {
+        List<Long> ids = request.getIds();
+        if (ids == null || ids.isEmpty()) {
+            return;
+        }
+        List<GalleryFile> files = fileRepository.findAllById(ids);
+        if (files.isEmpty()) {
+            return;
+        }
+        Set<Long> permittedIds = new HashSet<>();
+        for (GalleryFile file : files) {
+            enforceDeletePermission(file, principal);
+            permittedIds.add(file.getId());
+        }
+        List<String> storageKeys = files.stream()
+                .filter(file -> permittedIds.contains(file.getId()))
+                .map(GalleryFile::getStorageKey)
+                .filter(Objects::nonNull)
+                .toList();
+        fileRepository.deleteAll(files);
+        storageKeys.forEach(storageService::delete);
+        Map<String, Object> context = new HashMap<>();
+        context.put("fileIds", permittedIds);
+        activityRecorder.record(MODULE_NAME, "DELETE", "Bulk deleted gallery files", "SUCCESS", context);
+    }
+
+    public GalleryFileContent loadContent(Long id, UserPrincipal principal) {
+        GalleryFile file = fileRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "File not found"));
+        enforceViewPermission(file, principal);
+        return new GalleryFileContent(
+                storageService.loadAsResource(file.getStorageKey()),
+                file.getMimeType(),
+                file.getOriginalFilename()
+        );
+    }
+
+    public List<GalleryFolderDto> listFolders() {
+        List<GalleryFolder> folders = folderRepository.findAll(Sort.by(Sort.Direction.ASC, "path"));
+        List<GalleryFolderDto> result = new ArrayList<>();
+        result.add(new GalleryFolderDto(null, "All Files", "/", null, true));
+        for (GalleryFolder folder : folders) {
+            result.add(toDto(folder));
+        }
+        return result;
+    }
+
+    @Transactional
+    public GalleryFolderDto createFolder(GalleryFolderCreateRequest request) {
+        GalleryFolder folder = new GalleryFolder();
+        folder.setName(request.getName().trim());
+        folder.setParent(resolveFolder(request.getParentId()));
+        folder.refreshComputedFields();
+        ensureFolderPathUnique(folder);
+        GalleryFolder saved = folderRepository.save(folder);
+        activityRecorder.record(MODULE_NAME, "CREATE_FOLDER", "Created folder " + saved.getName(), "SUCCESS", buildFolderContext(saved));
+        return toDto(saved);
+    }
+
+    @Transactional
+    public GalleryFolderDto renameFolder(Long id, GalleryFolderRenameRequest request) {
+        GalleryFolder folder = folderRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Folder not found"));
+        folder.setName(request.getName().trim());
+        folder.refreshComputedFields();
+        ensureFolderPathUnique(folder);
+        GalleryFolder saved = folderRepository.save(folder);
+        refreshChildPaths(saved);
+        activityRecorder.record(MODULE_NAME, "UPDATE_FOLDER", "Renamed folder " + saved.getName(), "SUCCESS", buildFolderContext(saved));
+        return toDto(saved);
+    }
+
+    private void refreshChildPaths(GalleryFolder folder) {
+        List<GalleryFolder> children = folderRepository.findByParentId(folder.getId());
+        for (GalleryFolder child : children) {
+            child.refreshComputedFields();
+            folderRepository.save(child);
+            refreshChildPaths(child);
+        }
+    }
+
+    private void ensureFolderPathUnique(GalleryFolder folder) {
+        folderRepository.findByPath(folder.getPath())
+                .filter(existing -> !Objects.equals(existing.getId(), folder.getId()))
+                .ifPresent(existing -> {
+                    throw new ApiException(HttpStatus.BAD_REQUEST, "A folder with the same name already exists in this location");
+                });
+    }
+
+    private GalleryFile storeFile(GalleryFolder folder, User uploader, MultipartFile file, List<String> allowedExtensions) {
+        String originalName = Optional.ofNullable(file.getOriginalFilename()).orElse("file");
+        String extension = extractExtension(originalName);
+        if (extension.isBlank()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "File " + originalName + " is missing an extension");
+        }
+        if (allowedExtensions.stream().noneMatch(ext -> ext.equalsIgnoreCase(extension))) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "File type not allowed: " + extension);
+        }
+        String storageKey = storageService.store(file, folder != null ? folder.getPath() : "/", extension.toLowerCase(Locale.ROOT));
+        GalleryFile entity = new GalleryFile();
+        entity.setFolder(folder);
+        entity.setUploader(uploader);
+        entity.setDisplayName(deriveDisplayName(originalName));
+        entity.setOriginalFilename(originalName);
+        entity.setExtension(extension.toLowerCase(Locale.ROOT));
+        entity.setMimeType(file.getContentType());
+        entity.setSizeBytes(file.getSize());
+        entity.setStorageKey(storageKey);
+        return fileRepository.save(entity);
+    }
+
+    private String deriveDisplayName(String originalName) {
+        int dotIndex = originalName.lastIndexOf('.');
+        String base = dotIndex > 0 ? originalName.substring(0, dotIndex) : originalName;
+        String trimmed = base.trim();
+        return trimmed.isEmpty() ? "Untitled File" : trimmed;
+    }
+
+    private String extractExtension(String name) {
+        int dotIndex = name.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == name.length() - 1) {
+            return "";
+        }
+        return name.substring(dotIndex + 1).trim();
+    }
+
+    private Sort resolveSort(String sort, String direction) {
+        String normalizedSort = sort == null ? "createdAt" : sort.trim();
+        Sort.Direction sortDirection;
+        if (normalizedSort.equalsIgnoreCase("createdAt") && (direction == null || direction.isBlank())) {
+            sortDirection = Sort.Direction.DESC;
+        } else {
+            sortDirection = "asc".equalsIgnoreCase(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        }
+        return switch (normalizedSort.toLowerCase(Locale.ROOT)) {
+            case "size" -> Sort.by(sortDirection, "sizeBytes");
+            case "extension" -> Sort.by(sortDirection, "extension").and(Sort.by(Sort.Direction.ASC, "displayName"));
+            case "uploader" -> Sort.by(sortDirection, "uploader.email").and(Sort.by(Sort.Direction.ASC, "displayName"));
+            case "name" -> Sort.by(sortDirection, "displayName");
+            default -> Sort.by(sortDirection, "createdAt");
+        };
+    }
+
+    private boolean hasAuthority(UserPrincipal principal, String authority) {
+        if (principal == null || principal.getAuthorities() == null) {
+            return false;
+        }
+        return principal.getAuthorities().stream()
+                .anyMatch(grantedAuthority -> authority.equalsIgnoreCase(grantedAuthority.getAuthority()));
+    }
+
+    private Long resolveUserId(UserPrincipal principal) {
+        User user = resolveUser(principal);
+        return user != null ? user.getId() : null;
+    }
+
+    private User resolveUser(UserPrincipal principal) {
+        return principal != null ? principal.getUser() : null;
+    }
+
+    private void enforceDeletePermission(GalleryFile file, UserPrincipal principal) {
+        if (hasAuthority(principal, "GALLERY_DELETE_ALL")) {
+            return;
+        }
+        if (hasAuthority(principal, "GALLERY_DELETE_OWN")) {
+            Long currentUserId = resolveUserId(principal);
+            Long uploaderId = file.getUploader() != null ? file.getUploader().getId() : null;
+            if (currentUserId != null && currentUserId.equals(uploaderId)) {
+                return;
+            }
+        }
+        throw new ApiException(HttpStatus.FORBIDDEN, "Not authorized to delete this file");
+    }
+
+    private void enforceViewPermission(GalleryFile file, UserPrincipal principal) {
+        if (hasAuthority(principal, "GALLERY_VIEW_ALL")) {
+            return;
+        }
+        if (hasAuthority(principal, "GALLERY_VIEW_OWN")) {
+            Long currentUserId = resolveUserId(principal);
+            Long uploaderId = file.getUploader() != null ? file.getUploader().getId() : null;
+            if (currentUserId != null && currentUserId.equals(uploaderId)) {
+                return;
+            }
+        }
+        throw new ApiException(HttpStatus.FORBIDDEN, "Not authorized to view this file");
+    }
+
+    private GalleryFolder resolveFolder(Long folderId) {
+        if (folderId == null) {
+            return null;
+        }
+        return folderRepository.findById(folderId)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Folder not found"));
+    }
+
+    private GalleryFileDto toDto(GalleryFile file) {
+        GalleryFileDto dto = new GalleryFileDto();
+        dto.setId(file.getId());
+        dto.setDisplayName(file.getDisplayName());
+        dto.setOriginalFilename(file.getOriginalFilename());
+        dto.setExtension(file.getExtension());
+        dto.setMimeType(file.getMimeType());
+        dto.setSizeBytes(file.getSizeBytes());
+        dto.setUploadedAt(file.getCreatedAt());
+        if (file.getUploader() != null) {
+            dto.setUploadedById(file.getUploader().getId());
+            dto.setUploadedByEmail(file.getUploader().getEmail());
+            dto.setUploadedByName(file.getUploader().getFullName());
+        }
+        if (file.getFolder() != null) {
+            dto.setFolderId(file.getFolder().getId());
+            dto.setFolderPath(file.getFolder().getPath());
+        } else {
+            dto.setFolderId(null);
+            dto.setFolderPath("/");
+        }
+        return dto;
+    }
+
+    private GalleryFolderDto toDto(GalleryFolder folder) {
+        Long parentId = folder.getParent() != null ? folder.getParent().getId() : null;
+        return new GalleryFolderDto(folder.getId(), folder.getName(), folder.getPath(), parentId, false);
+    }
+
+    private Map<String, Object> buildFileContext(GalleryFile file) {
+        Map<String, Object> context = new HashMap<>();
+        context.put("fileId", file.getId());
+        context.put("fileName", file.getDisplayName());
+        context.put("folderId", file.getFolder() != null ? file.getFolder().getId() : null);
+        context.put("folderPath", file.getFolder() != null ? file.getFolder().getPath() : "/");
+        context.put("uploaderId", file.getUploader() != null ? file.getUploader().getId() : null);
+        return context;
+    }
+
+    private Map<String, Object> buildFolderContext(GalleryFolder folder) {
+        Map<String, Object> context = new HashMap<>();
+        context.put("folderId", folder.getId());
+        context.put("name", folder.getName());
+        context.put("path", folder.getPath());
+        context.put("parentId", folder.getParent() != null ? folder.getParent().getId() : null);
+        return context;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/service/GallerySettingsService.java
+++ b/backend/src/main/java/com/example/rbac/gallery/service/GallerySettingsService.java
@@ -1,0 +1,42 @@
+package com.example.rbac.gallery.service;
+
+import com.example.rbac.settings.model.Setting;
+import com.example.rbac.settings.repository.SettingRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class GallerySettingsService {
+
+    private static final String ALLOWED_EXTENSIONS_CODE = "gallery.allowed_extensions";
+
+    private final SettingRepository settingRepository;
+
+    public GallerySettingsService(SettingRepository settingRepository) {
+        this.settingRepository = settingRepository;
+    }
+
+    public List<String> resolveAllowedExtensions() {
+        Optional<Setting> setting = settingRepository.findByCode(ALLOWED_EXTENSIONS_CODE);
+        String configured = setting.map(Setting::getValue).orElse(null);
+        if (configured == null || configured.isBlank()) {
+            return List.of("png", "jpg", "jpeg", "pdf", "docx", "xlsx", "mp4");
+        }
+        return Arrays.stream(configured.split(","))
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> normalizeExtension(value))
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    private String normalizeExtension(String value) {
+        String sanitized = value.startsWith(".") ? value.substring(1) : value;
+        return sanitized.toLowerCase(Locale.ROOT);
+    }
+}

--- a/backend/src/main/java/com/example/rbac/gallery/service/GalleryStorageService.java
+++ b/backend/src/main/java/com/example/rbac/gallery/service/GalleryStorageService.java
@@ -1,0 +1,87 @@
+package com.example.rbac.gallery.service;
+
+import com.example.rbac.common.exception.ApiException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+public class GalleryStorageService {
+
+    private final Path storageRoot;
+
+    public GalleryStorageService(@Value("${app.gallery.storage-path:storage/gallery}") String storagePath) {
+        this.storageRoot = Paths.get(storagePath).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.storageRoot);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to initialize gallery storage directory", ex);
+        }
+    }
+
+    public String store(MultipartFile file, String folderPath, String extension) {
+        try {
+            Path targetDirectory = resolveFolderPath(folderPath);
+            Files.createDirectories(targetDirectory);
+            String filename = UUID.randomUUID() + (extension == null || extension.isBlank() ? "" : "." + extension);
+            Path destination = targetDirectory.resolve(filename);
+            Files.copy(file.getInputStream(), destination, StandardCopyOption.REPLACE_EXISTING);
+            return storageRoot.relativize(destination).toString().replace('\\', '/');
+        } catch (IOException ex) {
+            throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to store uploaded file");
+        }
+    }
+
+    public Resource loadAsResource(String storageKey) {
+        try {
+            Path filePath = storageRoot.resolve(storageKey).normalize();
+            if (!filePath.startsWith(storageRoot)) {
+                throw new ApiException(HttpStatus.BAD_REQUEST, "Invalid storage path");
+            }
+            Resource resource = new UrlResource(filePath.toUri());
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            }
+            throw new ApiException(HttpStatus.NOT_FOUND, "File not found");
+        } catch (MalformedURLException ex) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Invalid storage path");
+        }
+    }
+
+    public void delete(String storageKey) {
+        try {
+            if (storageKey == null || storageKey.isBlank()) {
+                return;
+            }
+            Path filePath = storageRoot.resolve(storageKey).normalize();
+            if (filePath.startsWith(storageRoot)) {
+                Files.deleteIfExists(filePath);
+            }
+        } catch (IOException ex) {
+            // ignore deletion errors to avoid blocking the request
+        }
+    }
+
+    private Path resolveFolderPath(String folderPath) {
+        if (folderPath == null || folderPath.isBlank() || "/".equals(folderPath)) {
+            return storageRoot;
+        }
+        String sanitized = folderPath;
+        if (sanitized.startsWith("/")) {
+            sanitized = sanitized.substring(1);
+        }
+        sanitized = sanitized.replace('\\', '/');
+        return storageRoot.resolve(sanitized).normalize();
+    }
+}

--- a/backend/src/main/java/com/example/rbac/setup/service/SetupService.java
+++ b/backend/src/main/java/com/example/rbac/setup/service/SetupService.java
@@ -281,6 +281,7 @@ public class SetupService {
                             List.of("PERMISSION_VIEW")
                     )
             )),
+            MenuDefinition.item("gallery", "Gallery", "🖼️", "/gallery", List.of("GALLERY_VIEW_ALL", "GALLERY_VIEW_OWN", "GALLERY_CREATE")),
             MenuDefinition.item("activity", "Activity", "📝", "/activity", List.of("ACTIVITY_VIEW")),
             MenuDefinition.item("settings", "Settings", "⚙️", "/settings", List.of("SETTINGS_VIEW")),
             MenuDefinition.item("setup", "Setup", "🧭", "/setup", List.of("SETUP_MANAGE")),

--- a/backend/src/main/resources/db/migration/V13__gallery_module.sql
+++ b/backend/src/main/resources/db/migration/V13__gallery_module.sql
@@ -1,0 +1,68 @@
+CREATE TABLE gallery_folders (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    slug VARCHAR(160) NOT NULL,
+    path VARCHAR(500) NOT NULL UNIQUE,
+    parent_id BIGINT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    CONSTRAINT fk_gallery_folders_parent FOREIGN KEY (parent_id) REFERENCES gallery_folders (id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_gallery_folders_parent ON gallery_folders(parent_id);
+
+CREATE TABLE gallery_files (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    folder_id BIGINT NULL,
+    uploader_id BIGINT NOT NULL,
+    display_name VARCHAR(255) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    extension VARCHAR(20) NOT NULL,
+    mime_type VARCHAR(100),
+    size_bytes BIGINT NOT NULL,
+    storage_key VARCHAR(500) NOT NULL UNIQUE,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    CONSTRAINT fk_gallery_files_folder FOREIGN KEY (folder_id) REFERENCES gallery_folders (id) ON DELETE SET NULL,
+    CONSTRAINT fk_gallery_files_uploader FOREIGN KEY (uploader_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_gallery_files_folder ON gallery_files(folder_id);
+CREATE INDEX idx_gallery_files_uploader ON gallery_files(uploader_id);
+CREATE INDEX idx_gallery_files_created_at ON gallery_files(created_at);
+CREATE INDEX idx_gallery_files_extension ON gallery_files(extension);
+
+INSERT IGNORE INTO permissions (code, name) VALUES
+    ('GALLERY_VIEW_OWN', 'Gallery: View Own Files'),
+    ('GALLERY_VIEW_ALL', 'Gallery: View All Files'),
+    ('GALLERY_CREATE', 'Gallery: Upload Files'),
+    ('GALLERY_EDIT_ALL', 'Gallery: Edit Files'),
+    ('GALLERY_DELETE_ALL', 'Gallery: Delete Any Files'),
+    ('GALLERY_DELETE_OWN', 'Gallery: Delete Own Files');
+
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code IN (
+    'GALLERY_VIEW_OWN',
+    'GALLERY_VIEW_ALL',
+    'GALLERY_CREATE',
+    'GALLERY_EDIT_ALL',
+    'GALLERY_DELETE_ALL',
+    'GALLERY_DELETE_OWN'
+)
+WHERE r.code = 'SUPER_ADMIN';
+
+INSERT INTO settings (
+    category_key, category_label, category_description,
+    section_key, section_label, section_description,
+    code, label, description, value, value_type, options_json, editable,
+    category_order, section_order, field_order
+) VALUES (
+    'files', 'File Library', 'Preferences for the internal gallery and file library.',
+    'gallery', 'Gallery Settings', 'Upload and validation rules for gallery content.',
+    'gallery.allowed_extensions', 'Allowed File Extensions', 'Comma-separated list of file extensions that can be uploaded to the gallery.',
+    'png,jpg,jpeg,pdf,docx,xlsx,mp4', 'STRING', NULL, TRUE,
+    5, 1, 1
+)
+ON DUPLICATE KEY UPDATE value = VALUES(value);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { applyPrimaryColor } from './utils/colors';
 import ActivityPage from './pages/ActivityPage';
 import ActivityDetailPage from './pages/ActivityDetailPage';
 import SetupPage from './pages/SetupPage';
+import GalleryPage from './pages/GalleryPage';
 
 const App = () => {
   const dispatch = useAppDispatch();
@@ -159,6 +160,13 @@ const App = () => {
           </Route>
           <Route element={<PermissionRoute required={['SETTINGS_VIEW']} />}>
             <Route path="/settings" element={<SettingsPage />} />
+          </Route>
+          <Route
+            element={
+              <PermissionRoute required={['GALLERY_VIEW_ALL', 'GALLERY_VIEW_OWN', 'GALLERY_CREATE']} />
+            }
+          >
+            <Route path="/gallery" element={<GalleryPage />} />
           </Route>
           <Route element={<PermissionRoute required={['SETUP_MANAGE']} />}>
             <Route path="/setup" element={<SetupPage />} />

--- a/frontend/src/constants/navigation.ts
+++ b/frontend/src/constants/navigation.ts
@@ -90,6 +90,15 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
     children: []
   },
   {
+    key: 'gallery',
+    label: 'Gallery',
+    icon: '🖼️',
+    path: '/gallery',
+    group: false,
+    permissions: ['GALLERY_VIEW_ALL', 'GALLERY_VIEW_OWN', 'GALLERY_CREATE'],
+    children: []
+  },
+  {
     key: 'settings',
     label: 'Settings',
     icon: '⚙️',

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -1,0 +1,639 @@
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '../services/http';
+import { useToast } from '../components/ToastProvider';
+import { useAppSelector } from '../app/hooks';
+import { hasAnyPermission } from '../utils/permissions';
+import { formatFileSize } from '../utils/files';
+import type { GalleryFile, GalleryFilePage, GalleryFolder } from '../types/gallery';
+import type { PermissionKey } from '../types/auth';
+
+const PAGE_SIZE_OPTIONS = [20, 50, 100];
+
+const SORT_OPTIONS = [
+  { value: 'newest', label: 'Newest first', sort: 'createdAt', direction: 'desc' },
+  { value: 'oldest', label: 'Oldest first', sort: 'createdAt', direction: 'asc' },
+  { value: 'smallest', label: 'Smallest file size', sort: 'size', direction: 'asc' },
+  { value: 'largest', label: 'Largest file size', sort: 'size', direction: 'desc' },
+  { value: 'type', label: 'File type', sort: 'extension', direction: 'asc' },
+  { value: 'uploader', label: 'Uploader', sort: 'uploader', direction: 'asc' }
+] as const;
+
+type SortOptionValue = (typeof SORT_OPTIONS)[number]['value'];
+
+type EditModalState = {
+  file: GalleryFile;
+  name: string;
+  folderId: number | null;
+};
+
+type FolderModalState = {
+  name: string;
+  parentId: number | null;
+};
+
+const formatDateTime = (value: string) => {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+};
+
+const resolveFileUrl = (id: number) => {
+  const baseUrl = api.defaults.baseURL ?? '';
+  return `${baseUrl.replace(/\/$/, '')}/gallery/files/${id}/content`;
+};
+
+const GalleryPage = () => {
+  const queryClient = useQueryClient();
+  const { notify } = useToast();
+  const { permissions: grantedPermissions, user } = useAppSelector((state) => state.auth);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+  const [sortValue, setSortValue] = useState<SortOptionValue>('newest');
+  const [folderFilter, setFolderFilter] = useState<number | null>(null);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [uploaderFilter, setUploaderFilter] = useState('');
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [editModal, setEditModal] = useState<EditModalState | null>(null);
+  const [folderModal, setFolderModal] = useState<FolderModalState | null>(null);
+
+  const granted = (grantedPermissions as PermissionKey[]) ?? [];
+  const currentUserId = user?.id ?? null;
+
+  const canUpload = useMemo(() => hasAnyPermission(granted, ['GALLERY_CREATE']), [granted]);
+  const canEdit = useMemo(() => hasAnyPermission(granted, ['GALLERY_EDIT_ALL']), [granted]);
+  const canDeleteAll = useMemo(() => hasAnyPermission(granted, ['GALLERY_DELETE_ALL']), [granted]);
+  const canDeleteOwn = useMemo(() => hasAnyPermission(granted, ['GALLERY_DELETE_OWN']), [granted]);
+  const canViewAll = useMemo(() => hasAnyPermission(granted, ['GALLERY_VIEW_ALL']), [granted]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearchTerm(searchDraft.trim());
+      setPage(0);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [pageSize, sortValue, folderFilter, uploaderFilter]);
+
+  const foldersQuery = useQuery<GalleryFolder[]>({
+    queryKey: ['gallery', 'folders'],
+    queryFn: async () => {
+      const { data } = await api.get<GalleryFolder[]>('/gallery/folders');
+      return data;
+    }
+  });
+
+  const filesQuery = useQuery<GalleryFilePage>({
+    queryKey: [
+      'gallery',
+      'files',
+      { page, pageSize, sortValue, folderFilter, uploaderFilter: canViewAll ? uploaderFilter : '', searchTerm }
+    ],
+    queryFn: async () => {
+      const sortOption = SORT_OPTIONS.find((option) => option.value === sortValue) ?? SORT_OPTIONS[0];
+      const params: Record<string, unknown> = {
+        page,
+        size: pageSize,
+        sort: sortOption.sort,
+        direction: sortOption.direction
+      };
+      if (folderFilter !== null) {
+        params.folderId = folderFilter;
+      }
+      if (searchTerm) {
+        params.search = searchTerm;
+      }
+      if (canViewAll && uploaderFilter.trim()) {
+        params.uploader = uploaderFilter.trim();
+      }
+      const { data } = await api.get<GalleryFilePage>('/gallery/files', { params });
+      return data;
+    },
+    placeholderData: (previousData) => previousData
+  });
+
+  const invalidateGallery = () => {
+    queryClient.invalidateQueries({ queryKey: ['gallery', 'files'] });
+  };
+
+  const uploadFiles = useMutation({
+    mutationFn: async (files: File[]) => {
+      const formData = new FormData();
+      files.forEach((file) => formData.append('files', file));
+      if (folderFilter !== null) {
+        formData.append('folderId', folderFilter.toString());
+      }
+      const { data } = await api.post<GalleryFile[]>('/gallery/files', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
+      return data;
+    },
+    onSuccess: (uploaded) => {
+      notify({ type: 'success', message: uploaded.length === 1 ? 'File uploaded successfully.' : 'Files uploaded successfully.' });
+      invalidateGallery();
+      setSelectedIds([]);
+    },
+    onError: () => {
+      notify({ type: 'error', message: 'Unable to upload files. Please check the allowed file types.' });
+    }
+  });
+
+  const deleteFiles = useMutation({
+    mutationFn: async (ids: number[]) => {
+      if (ids.length === 1) {
+        await api.delete(`/gallery/files/${ids[0]}`);
+      } else {
+        await api.post('/gallery/files/bulk-delete', { ids });
+      }
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'File(s) deleted successfully.' });
+      invalidateGallery();
+      setSelectedIds([]);
+    },
+    onError: () => {
+      notify({ type: 'error', message: 'Unable to delete the selected files.' });
+    }
+  });
+
+  const updateFile = useMutation({
+    mutationFn: async (payload: { id: number; displayName: string; folderId: number | null }) => {
+      const { data } = await api.patch<GalleryFile>(`/gallery/files/${payload.id}`, {
+        displayName: payload.displayName,
+        targetFolderId: payload.folderId
+      });
+      return data;
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'File updated successfully.' });
+      invalidateGallery();
+      setEditModal(null);
+    },
+    onError: () => {
+      notify({ type: 'error', message: 'Unable to update the file.' });
+    }
+  });
+
+  const createFolder = useMutation({
+    mutationFn: async (payload: { name: string; parentId: number | null }) => {
+      const { data } = await api.post<GalleryFolder>('/gallery/folders', payload);
+      return data;
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Folder created successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['gallery', 'folders'] });
+      setFolderModal(null);
+    },
+    onError: () => {
+      notify({ type: 'error', message: 'Unable to create folder. Ensure the name is unique.' });
+    }
+  });
+
+  const files = filesQuery.data?.content ?? [];
+  const totalPages = filesQuery.data?.totalPages ?? 0;
+
+  const allSelected = files.length > 0 && selectedIds.length === files.length;
+  const partiallySelected = selectedIds.length > 0 && selectedIds.length < files.length;
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds([]);
+      return;
+    }
+    setSelectedIds(files.map((file) => file.id));
+  };
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds((previous) => (previous.includes(id) ? previous.filter((value) => value !== id) : [...previous, id]));
+  };
+
+  const handleUploadButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const inputFiles = Array.from(event.target.files ?? []);
+    if (!inputFiles.length) {
+      return;
+    }
+    uploadFiles.mutate(inputFiles);
+    event.target.value = '';
+  };
+
+  const handleDeleteSelected = () => {
+    if (!selectedIds.length) {
+      return;
+    }
+    deleteFiles.mutate(selectedIds);
+  };
+
+  const handleDeleteSingle = (id: number) => {
+    deleteFiles.mutate([id]);
+  };
+
+  const openEditModal = (file: GalleryFile) => {
+    setEditModal({ file, name: file.displayName, folderId: file.folderId ?? null });
+  };
+
+  const openFolderModal = () => {
+    setFolderModal({ name: '', parentId: folderFilter });
+  };
+
+  const renderFolderOptions = () => {
+    const data = foldersQuery.data ?? [
+      { id: null, name: 'All Files', path: '/', parentId: null, root: true }
+    ];
+    return data.map((folder) => (
+      <option key={`folder-${folder.id ?? 'root'}`} value={folder.id ?? ''}>
+        {folder.name}
+      </option>
+    ));
+  };
+
+  const resolvedFolders = foldersQuery.data ?? [];
+  const resolveFolderName = (folderId?: number | null) => {
+    if (folderId === null || folderId === undefined) {
+      return 'All Files';
+    }
+    const folder = resolvedFolders.find((item) => item.id === folderId);
+    return folder?.name ?? 'All Files';
+  };
+
+  const canDelete = canDeleteAll || canDeleteOwn;
+
+  return (
+    <div className="space-y-6">
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleFileInputChange}
+        disabled={!canUpload || uploadFiles.isPending}
+      />
+
+      <div className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-900">Gallery</h1>
+            <p className="text-sm text-slate-500">Upload, organize, and manage files across your workspace.</p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            {canUpload && (
+              <button
+                type="button"
+                onClick={handleUploadButtonClick}
+                disabled={uploadFiles.isPending}
+                className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60"
+              >
+                <span className="text-lg">⬆️</span>
+                Upload
+              </button>
+            )}
+            {canUpload && (
+              <button
+                type="button"
+                onClick={openFolderModal}
+                className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-primary hover:text-primary"
+              >
+                <span className="text-lg">📁</span>
+                New Folder
+              </button>
+            )}
+            {canDelete && (
+              <button
+                type="button"
+                onClick={handleDeleteSelected}
+                disabled={!selectedIds.length || deleteFiles.isPending}
+                className="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 shadow-sm transition hover:border-rose-300 hover:bg-rose-100 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+              >
+                <span className="text-lg">🗑️</span>
+                Delete Selected
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-4">
+          <div className="lg:col-span-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Search</label>
+            <input
+              type="search"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+              placeholder="Search by name or extension"
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Folder</label>
+            <select
+              value={folderFilter ?? ''}
+              onChange={(event) => {
+                const value = event.target.value;
+                setFolderFilter(value === '' ? null : Number(value));
+              }}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            >
+              {renderFolderOptions()}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Sort by</label>
+            <select
+              value={sortValue}
+              onChange={(event) => setSortValue(event.target.value as SortOptionValue)}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            >
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {canViewAll && (
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Filter by uploader</label>
+            <input
+              type="text"
+              value={uploaderFilter}
+              onChange={(event) => setUploaderFilter(event.target.value)}
+              placeholder="Enter email or name"
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="w-12 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    ref={(element) => {
+                      if (element) {
+                        element.indeterminate = partiallySelected;
+                      }
+                    }}
+                    onChange={toggleSelectAll}
+                  />
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">File</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Type</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Size</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Folder</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Uploaded</th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {files.map((file) => {
+                const isOwner = currentUserId !== null && currentUserId === (file.uploadedById ?? null);
+                const canDeleteFile = canDeleteAll || (canDeleteOwn && isOwner);
+                return (
+                  <tr key={file.id} className="hover:bg-slate-50/60">
+                    <td className="px-4 py-3">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.includes(file.id)}
+                        onChange={() => toggleSelect(file.id)}
+                      />
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-xs font-semibold uppercase text-slate-600">
+                          {file.extension.slice(0, 4)}
+                        </div>
+                        <div>
+                          <div className="font-medium text-slate-800">{file.displayName}</div>
+                          <div className="text-xs text-slate-500">{file.originalFilename}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{file.extension.toUpperCase()}</td>
+                    <td className="px-4 py-3 text-slate-600">{formatFileSize(file.sizeBytes)}</td>
+                    <td className="px-4 py-3 text-slate-600">{resolveFolderName(file.folderId)}</td>
+                    <td className="px-4 py-3 text-slate-600">
+                      <div className="flex flex-col">
+                        <span>{file.uploadedByName ?? file.uploadedByEmail ?? '—'}</span>
+                        <span className="text-xs text-slate-400">{formatDateTime(file.uploadedAt)}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-3">
+                        <a
+                          href={resolveFileUrl(file.id)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sm font-semibold text-primary hover:text-primary/80"
+                        >
+                          View
+                        </a>
+                        {canEdit && (
+                          <button
+                            type="button"
+                            onClick={() => openEditModal(file)}
+                            className="text-sm font-semibold text-slate-600 hover:text-primary"
+                          >
+                            Edit
+                          </button>
+                        )}
+                        {canDeleteFile && (
+                          <button
+                            type="button"
+                            onClick={() => handleDeleteSingle(file.id)}
+                            className="text-sm font-semibold text-rose-600 hover:text-rose-500"
+                          >
+                            Delete
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+              {!files.length && (
+                <tr>
+                  <td colSpan={7} className="px-4 py-16 text-center text-sm text-slate-500">
+                    {filesQuery.isFetching ? 'Loading files…' : 'No files found for the selected filters.'}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex flex-col gap-4 border-t border-slate-200 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3 text-sm text-slate-600">
+            <span>Rows per page</span>
+            <select
+              value={pageSize}
+              onChange={(event) => setPageSize(Number(event.target.value))}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            >
+              {PAGE_SIZE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-slate-600">
+            <button
+              type="button"
+              onClick={() => setPage((previous) => Math.max(previous - 1, 0))}
+              disabled={page === 0}
+              className="rounded-lg border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+            >
+              Previous
+            </button>
+            <span>
+              Page {Math.min(page + 1, totalPages || 1)} of {totalPages || 1}
+            </span>
+            <button
+              type="button"
+              onClick={() => setPage((previous) => (previous + 1 < totalPages ? previous + 1 : previous))}
+              disabled={page + 1 >= totalPages}
+              className="rounded-lg border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {editModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+            <h2 className="text-lg font-semibold text-slate-900">Edit file</h2>
+            <div className="mt-4">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">File name</label>
+              <input
+                type="text"
+                value={editModal.name}
+                onChange={(event) => setEditModal({ ...editModal, name: event.target.value })}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+              />
+            </div>
+            <div className="mt-4">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Folder</label>
+              <select
+                value={editModal.folderId ?? ''}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setEditModal({ ...editModal, folderId: value === '' ? null : Number(value) });
+                }}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+              >
+                {renderFolderOptions()}
+              </select>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setEditModal(null)}
+                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-400"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  updateFile.mutate({
+                    id: editModal.file.id,
+                    displayName: editModal.name.trim() || editModal.file.displayName,
+                    folderId: editModal.folderId
+                  })
+                }
+                disabled={updateFile.isPending}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60"
+              >
+                Save changes
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {folderModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+            <h2 className="text-lg font-semibold text-slate-900">Create folder</h2>
+            <div className="mt-4">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Folder name</label>
+              <input
+                type="text"
+                value={folderModal.name}
+                onChange={(event) => setFolderModal({ ...folderModal, name: event.target.value })}
+                placeholder="e.g. Design assets"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+              />
+            </div>
+            <div className="mt-4">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Parent folder</label>
+              <select
+                value={folderModal.parentId ?? ''}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setFolderModal({ ...folderModal, parentId: value === '' ? null : Number(value) });
+                }}
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+              >
+                {renderFolderOptions()}
+              </select>
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setFolderModal(null)}
+                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-slate-400"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const trimmed = folderModal.name.trim();
+                  if (!trimmed) {
+                    notify({ type: 'error', message: 'Folder name cannot be empty.' });
+                    return;
+                  }
+                  createFolder.mutate({ name: trimmed, parentId: folderModal.parentId });
+                }}
+                disabled={createFolder.isPending}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60"
+              >
+                Create folder
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GalleryPage;

--- a/frontend/src/types/gallery.ts
+++ b/frontend/src/types/gallery.ts
@@ -1,0 +1,26 @@
+import type { Pagination } from './models';
+
+export interface GalleryFile {
+  id: number;
+  displayName: string;
+  originalFilename: string;
+  extension: string;
+  mimeType?: string | null;
+  sizeBytes: number;
+  uploadedAt: string;
+  uploadedById?: number | null;
+  uploadedByName?: string | null;
+  uploadedByEmail?: string | null;
+  folderId?: number | null;
+  folderPath: string;
+}
+
+export interface GalleryFolder {
+  id: number | null;
+  name: string;
+  path: string;
+  parentId: number | null;
+  root: boolean;
+}
+
+export type GalleryFilePage = Pagination<GalleryFile>;

--- a/frontend/src/utils/files.ts
+++ b/frontend/src/utils/files.ts
@@ -1,0 +1,12 @@
+export const formatFileSize = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return '0 B';
+  }
+  if (bytes === 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};


### PR DESCRIPTION
## Summary
- add Flyway migration and Spring components for a gallery module that handles file metadata, storage, and folder management with permission-aware endpoints
- expose REST APIs for uploading, listing, moving, and deleting gallery files plus supporting folder CRUD and storage helpers
- create a dedicated Gallery page in the front-end with sorting, filtering, bulk actions, and new navigation/menu wiring

## Testing
- `npm run build`
- `mvn -q -DskipTests package` *(fails: Maven could not download dependencies because central repository access returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e52984d27c83238cbe03e82759286f