### PR TITLE
Refine gallery ownership and UI

### DIFF
--- a/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
+++ b/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
@@ -87,14 +87,15 @@ public class GalleryController {
 
     @GetMapping("/folders")
     @PreAuthorize("hasAnyAuthority('GALLERY_VIEW_ALL','GALLERY_VIEW_OWN','GALLERY_CREATE','GALLERY_EDIT_ALL')")
-    public List<GalleryFolderDto> listFolders() {
-        return galleryService.listFolders();
+    public List<GalleryFolderDto> listFolders(@AuthenticationPrincipal UserPrincipal principal) {
+        return galleryService.listFolders(principal);
     }
 
     @PostMapping("/folders")
     @PreAuthorize("hasAuthority('GALLERY_CREATE')")
-    public GalleryFolderDto createFolder(@Valid @RequestBody GalleryFolderCreateRequest request) {
-        return galleryService.createFolder(request);
+    public GalleryFolderDto createFolder(@Valid @RequestBody GalleryFolderCreateRequest request,
+                                         @AuthenticationPrincipal UserPrincipal principal) {
+        return galleryService.createFolder(request, principal);
     }
 
     @PatchMapping("/folders/{id}")

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderDto.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderDto.java
@@ -7,16 +7,32 @@ public class GalleryFolderDto {
     private String path;
     private Long parentId;
     private boolean root;
+    private Long ownerId;
+    private String ownerName;
+    private String ownerEmail;
+    private String ownerKey;
 
     public GalleryFolderDto() {
     }
 
-    public GalleryFolderDto(Long id, String name, String path, Long parentId, boolean root) {
+    public GalleryFolderDto(Long id,
+                            String name,
+                            String path,
+                            Long parentId,
+                            boolean root,
+                            Long ownerId,
+                            String ownerName,
+                            String ownerEmail,
+                            String ownerKey) {
         this.id = id;
         this.name = name;
         this.path = path;
         this.parentId = parentId;
         this.root = root;
+        this.ownerId = ownerId;
+        this.ownerName = ownerName;
+        this.ownerEmail = ownerEmail;
+        this.ownerKey = ownerKey;
     }
 
     public Long getId() {
@@ -57,5 +73,37 @@ public class GalleryFolderDto {
 
     public void setRoot(boolean root) {
         this.root = root;
+    }
+
+    public Long getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(Long ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public String getOwnerEmail() {
+        return ownerEmail;
+    }
+
+    public void setOwnerEmail(String ownerEmail) {
+        this.ownerEmail = ownerEmail;
+    }
+
+    public String getOwnerKey() {
+        return ownerKey;
+    }
+
+    public void setOwnerKey(String ownerKey) {
+        this.ownerKey = ownerKey;
     }
 }

--- a/backend/src/main/java/com/example/rbac/gallery/model/GalleryFolder.java
+++ b/backend/src/main/java/com/example/rbac/gallery/model/GalleryFolder.java
@@ -1,5 +1,6 @@
 package com.example.rbac.gallery.model;
 
+import com.example.rbac.users.model.User;
 import jakarta.persistence.*;
 
 import java.text.Normalizer;
@@ -26,6 +27,10 @@ public class GalleryFolder {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private GalleryFolder parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private User owner;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -69,14 +74,25 @@ public class GalleryFolder {
     }
 
     private String buildPath() {
-        String parentPath = parent != null ? parent.getPath() : "/";
+        String parentPath = parent != null ? parent.getPath() : null;
         if (parentPath == null || parentPath.isBlank() || "/".equals(parentPath)) {
+            String ownerSegment = buildOwnerSegment();
+            if (ownerSegment != null) {
+                return "/" + ownerSegment + "/" + slug;
+            }
             return "/" + slug;
         }
         if (parentPath.endsWith("/")) {
             return parentPath + slug;
         }
         return parentPath + "/" + slug;
+    }
+
+    private String buildOwnerSegment() {
+        if (owner == null || owner.getId() == null) {
+            return null;
+        }
+        return "usr-" + owner.getId();
     }
 
     public Long getId() {
@@ -133,5 +149,13 @@ public class GalleryFolder {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
     }
 }

--- a/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFolderRepository.java
+++ b/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFolderRepository.java
@@ -1,6 +1,7 @@
 package com.example.rbac.gallery.repository;
 
 import com.example.rbac.gallery.model.GalleryFolder;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,4 +14,8 @@ public interface GalleryFolderRepository extends JpaRepository<GalleryFolder, Lo
     List<GalleryFolder> findByParentId(Long parentId);
 
     List<GalleryFolder> findByParentIsNull();
+
+    List<GalleryFolder> findByOwnerId(Long ownerId, Sort sort);
+
+    Optional<GalleryFolder> findByOwnerIdAndParentIsNull(Long ownerId);
 }

--- a/backend/src/main/resources/db/migration/V14__gallery_folder_ownership.sql
+++ b/backend/src/main/resources/db/migration/V14__gallery_folder_ownership.sql
@@ -1,0 +1,13 @@
+ALTER TABLE gallery_folders
+    ADD COLUMN owner_id BIGINT NULL;
+
+ALTER TABLE gallery_folders
+    ADD CONSTRAINT fk_gallery_folders_owner FOREIGN KEY (owner_id) REFERENCES users (id) ON DELETE CASCADE;
+
+CREATE INDEX idx_gallery_folders_owner ON gallery_folders(owner_id);
+
+UPDATE gallery_folders gf
+LEFT JOIN gallery_files gfi ON gfi.folder_id = gf.id
+SET gf.owner_id = gfi.uploader_id
+WHERE gf.owner_id IS NULL
+  AND gfi.uploader_id IS NOT NULL;

--- a/frontend/src/types/gallery.ts
+++ b/frontend/src/types/gallery.ts
@@ -21,6 +21,10 @@ export interface GalleryFolder {
   path: string;
   parentId: number | null;
   root: boolean;
+  ownerId: number | null;
+  ownerName?: string | null;
+  ownerEmail?: string | null;
+  ownerKey?: string | null;
 }
 
 export type GalleryFilePage = Pagination<GalleryFile>;


### PR DESCRIPTION
## Summary
- enforce per-user gallery folder ownership with a new migration and service updates
- redesign the gallery page with a sidebar tree, breadcrumbs, and updated folder metadata
- route direct permission override saves through the dedicated permissions endpoint

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated modules)*
- mvn test *(fails: Maven Central requests are blocked with HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e53ae15da08323b4ff14c896223097