### PR TITLE
Redesign gallery UI with Google Drive layout

### DIFF
--- a/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
+++ b/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
@@ -87,14 +87,15 @@ public class GalleryController {
 
     @GetMapping("/folders")
     @PreAuthorize("hasAnyAuthority('GALLERY_VIEW_ALL','GALLERY_VIEW_OWN','GALLERY_CREATE','GALLERY_EDIT_ALL')")
-    public List<GalleryFolderDto> listFolders() {
-        return galleryService.listFolders();
+    public List<GalleryFolderDto> listFolders(@AuthenticationPrincipal UserPrincipal principal) {
+        return galleryService.listFolders(principal);
     }
 
     @PostMapping("/folders")
     @PreAuthorize("hasAuthority('GALLERY_CREATE')")
-    public GalleryFolderDto createFolder(@Valid @RequestBody GalleryFolderCreateRequest request) {
-        return galleryService.createFolder(request);
+    public GalleryFolderDto createFolder(@Valid @RequestBody GalleryFolderCreateRequest request,
+                                         @AuthenticationPrincipal UserPrincipal principal) {
+        return galleryService.createFolder(request, principal);
     }
 
     @PatchMapping("/folders/{id}")

--- a/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderDto.java
+++ b/backend/src/main/java/com/example/rbac/gallery/dto/GalleryFolderDto.java
@@ -7,16 +7,32 @@ public class GalleryFolderDto {
     private String path;
     private Long parentId;
     private boolean root;
+    private Long ownerId;
+    private String ownerName;
+    private String ownerEmail;
+    private String ownerKey;
 
     public GalleryFolderDto() {
     }
 
-    public GalleryFolderDto(Long id, String name, String path, Long parentId, boolean root) {
+    public GalleryFolderDto(Long id,
+                            String name,
+                            String path,
+                            Long parentId,
+                            boolean root,
+                            Long ownerId,
+                            String ownerName,
+                            String ownerEmail,
+                            String ownerKey) {
         this.id = id;
         this.name = name;
         this.path = path;
         this.parentId = parentId;
         this.root = root;
+        this.ownerId = ownerId;
+        this.ownerName = ownerName;
+        this.ownerEmail = ownerEmail;
+        this.ownerKey = ownerKey;
     }
 
     public Long getId() {
@@ -57,5 +73,37 @@ public class GalleryFolderDto {
 
     public void setRoot(boolean root) {
         this.root = root;
+    }
+
+    public Long getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(Long ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
+    }
+
+    public String getOwnerEmail() {
+        return ownerEmail;
+    }
+
+    public void setOwnerEmail(String ownerEmail) {
+        this.ownerEmail = ownerEmail;
+    }
+
+    public String getOwnerKey() {
+        return ownerKey;
+    }
+
+    public void setOwnerKey(String ownerKey) {
+        this.ownerKey = ownerKey;
     }
 }

--- a/backend/src/main/java/com/example/rbac/gallery/model/GalleryFolder.java
+++ b/backend/src/main/java/com/example/rbac/gallery/model/GalleryFolder.java
@@ -1,5 +1,6 @@
 package com.example.rbac.gallery.model;
 
+import com.example.rbac.users.model.User;
 import jakarta.persistence.*;
 
 import java.text.Normalizer;
@@ -26,6 +27,10 @@ public class GalleryFolder {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private GalleryFolder parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private User owner;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -69,14 +74,25 @@ public class GalleryFolder {
     }
 
     private String buildPath() {
-        String parentPath = parent != null ? parent.getPath() : "/";
+        String parentPath = parent != null ? parent.getPath() : null;
         if (parentPath == null || parentPath.isBlank() || "/".equals(parentPath)) {
+            String ownerSegment = buildOwnerSegment();
+            if (ownerSegment != null) {
+                return "/" + ownerSegment + "/" + slug;
+            }
             return "/" + slug;
         }
         if (parentPath.endsWith("/")) {
             return parentPath + slug;
         }
         return parentPath + "/" + slug;
+    }
+
+    private String buildOwnerSegment() {
+        if (owner == null || owner.getId() == null) {
+            return null;
+        }
+        return "usr-" + owner.getId();
     }
 
     public Long getId() {
@@ -133,5 +149,13 @@ public class GalleryFolder {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
     }
 }

--- a/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFolderRepository.java
+++ b/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFolderRepository.java
@@ -1,6 +1,7 @@
 package com.example.rbac.gallery.repository;
 
 import com.example.rbac.gallery.model.GalleryFolder;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,4 +14,8 @@ public interface GalleryFolderRepository extends JpaRepository<GalleryFolder, Lo
     List<GalleryFolder> findByParentId(Long parentId);
 
     List<GalleryFolder> findByParentIsNull();
+
+    List<GalleryFolder> findByOwnerId(Long ownerId, Sort sort);
+
+    Optional<GalleryFolder> findByOwnerIdAndParentIsNull(Long ownerId);
 }

--- a/backend/src/main/resources/db/migration/V14__gallery_folder_ownership.sql
+++ b/backend/src/main/resources/db/migration/V14__gallery_folder_ownership.sql
@@ -1,0 +1,13 @@
+ALTER TABLE gallery_folders
+    ADD COLUMN owner_id BIGINT NULL;
+
+ALTER TABLE gallery_folders
+    ADD CONSTRAINT fk_gallery_folders_owner FOREIGN KEY (owner_id) REFERENCES users (id) ON DELETE CASCADE;
+
+CREATE INDEX idx_gallery_folders_owner ON gallery_folders(owner_id);
+
+UPDATE gallery_folders gf
+LEFT JOIN gallery_files gfi ON gfi.folder_id = gf.id
+SET gf.owner_id = gfi.uploader_id
+WHERE gf.owner_id IS NULL
+  AND gfi.uploader_id IS NOT NULL;

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '../services/http';
 import { useToast } from '../components/ToastProvider';
@@ -32,6 +32,17 @@ type FolderModalState = {
   parentId: number | null;
 };
 
+type FolderTreeNode = {
+  key: string;
+  label: string;
+  folderId: number | null;
+  ownerId: number | null;
+  depth: number;
+  children: FolderTreeNode[];
+  description?: string;
+  isSynthetic: boolean;
+};
+
 const formatDateTime = (value: string) => {
   if (!value) {
     return '—';
@@ -54,6 +65,85 @@ const resolveFileUrl = (id: number) => {
   return `${baseUrl.replace(/\/$/, '')}/gallery/files/${id}/content`;
 };
 
+const buildFolderTree = (
+  folders: GalleryFolder[],
+  currentUserId: number | null,
+  canViewAll: boolean
+): FolderTreeNode[] => {
+  const concreteFolders = folders.filter((folder): folder is GalleryFolder & { id: number } => folder.id !== null);
+  const grouped = new Map<number | null, (GalleryFolder & { id: number })[]>();
+
+  concreteFolders.forEach((folder) => {
+    const ownerId = folder.ownerId ?? null;
+    const existing = grouped.get(ownerId);
+    if (existing) {
+      existing.push(folder);
+    } else {
+      grouped.set(ownerId, [folder]);
+    }
+  });
+
+  if (!canViewAll && currentUserId !== null && !grouped.has(currentUserId)) {
+    grouped.set(currentUserId, []);
+  }
+
+  const buildHierarchy = (
+    items: (GalleryFolder & { id: number })[],
+    parentId: number | null,
+    depth: number
+  ): FolderTreeNode[] => {
+    const children = items.filter((item) => (item.parentId ?? null) === parentId);
+    children.sort((a, b) => a.name.localeCompare(b.name));
+    return children.map((child) => ({
+      key: `folder-${child.id}`,
+      label: child.name,
+      folderId: child.id,
+      ownerId: child.ownerId ?? null,
+      depth,
+      description: undefined,
+      isSynthetic: false,
+      children: buildHierarchy(items, child.id, depth + 1)
+    }));
+  };
+
+  const nodes: FolderTreeNode[] = [];
+  grouped.forEach((items, ownerId) => {
+    const sample = items[0];
+    const hasOwner = ownerId !== null;
+    const ownerLabel = (() => {
+      if (!hasOwner) {
+        return canViewAll ? 'Unassigned' : 'My Library';
+      }
+      if (!canViewAll && currentUserId !== null && ownerId === currentUserId) {
+        return 'My Library';
+      }
+      return sample?.ownerKey ?? sample?.ownerEmail ?? sample?.ownerName ?? `User ${ownerId}`;
+    })();
+    const ownerDescription = (() => {
+      if (!sample) {
+        return undefined;
+      }
+      if (!canViewAll && currentUserId !== null && ownerId === currentUserId) {
+        return sample.ownerEmail ?? undefined;
+      }
+      return sample.ownerEmail ?? sample.ownerName ?? undefined;
+    })();
+    nodes.push({
+      key: hasOwner ? `owner-${ownerId}` : 'owner-unknown',
+      label: ownerLabel,
+      folderId: null,
+      ownerId,
+      depth: 0,
+      description: ownerDescription,
+      isSynthetic: true,
+      children: buildHierarchy(items, null, 1)
+    });
+  });
+
+  nodes.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+  return nodes;
+};
+
 const GalleryPage = () => {
   const queryClient = useQueryClient();
   const { notify } = useToast();
@@ -64,12 +154,14 @@ const GalleryPage = () => {
   const [pageSize, setPageSize] = useState(20);
   const [sortValue, setSortValue] = useState<SortOptionValue>('newest');
   const [folderFilter, setFolderFilter] = useState<number | null>(null);
+  const [ownerFilter, setOwnerFilter] = useState<number | null>(null);
   const [searchDraft, setSearchDraft] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [uploaderFilter, setUploaderFilter] = useState('');
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [editModal, setEditModal] = useState<EditModalState | null>(null);
   const [folderModal, setFolderModal] = useState<FolderModalState | null>(null);
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
 
   const granted = (grantedPermissions as PermissionKey[]) ?? [];
   const currentUserId = user?.id ?? null;
@@ -90,7 +182,7 @@ const GalleryPage = () => {
 
   useEffect(() => {
     setPage(0);
-  }, [pageSize, sortValue, folderFilter, uploaderFilter]);
+  }, [pageSize, sortValue, folderFilter, ownerFilter, uploaderFilter]);
 
   const foldersQuery = useQuery<GalleryFolder[]>({
     queryKey: ['gallery', 'folders'],
@@ -104,7 +196,15 @@ const GalleryPage = () => {
     queryKey: [
       'gallery',
       'files',
-      { page, pageSize, sortValue, folderFilter, uploaderFilter: canViewAll ? uploaderFilter : '', searchTerm }
+      {
+        page,
+        pageSize,
+        sortValue,
+        folderFilter,
+        ownerFilter: canViewAll ? ownerFilter : currentUserId,
+        uploaderFilter: canViewAll ? uploaderFilter : '',
+        searchTerm
+      }
     ],
     queryFn: async () => {
       const sortOption = SORT_OPTIONS.find((option) => option.value === sortValue) ?? SORT_OPTIONS[0];
@@ -116,6 +216,8 @@ const GalleryPage = () => {
       };
       if (folderFilter !== null) {
         params.folderId = folderFilter;
+      } else if (canViewAll && ownerFilter !== null) {
+        params.uploaderId = ownerFilter;
       }
       if (searchTerm) {
         params.search = searchTerm;
@@ -256,27 +358,250 @@ const GalleryPage = () => {
     setFolderModal({ name: '', parentId: folderFilter });
   };
 
-  const renderFolderOptions = () => {
-    const data = foldersQuery.data ?? [
-      { id: null, name: 'All Files', path: '/', parentId: null, root: true }
-    ];
-    return data.map((folder) => (
-      <option key={`folder-${folder.id ?? 'root'}`} value={folder.id ?? ''}>
-        {folder.name}
-      </option>
-    ));
-  };
+  const foldersData = foldersQuery.data ?? [];
+  const folderMap = useMemo(() => {
+    const map = new Map<number, GalleryFolder & { id: number }>();
+    foldersData.forEach((folder) => {
+      if (folder.id !== null) {
+        map.set(folder.id, folder as GalleryFolder & { id: number });
+      }
+    });
+    return map;
+  }, [foldersData]);
 
-  const resolvedFolders = foldersQuery.data ?? [];
-  const resolveFolderName = (folderId?: number | null) => {
+  const resolveFolderName = useCallback((folderId?: number | null) => {
     if (folderId === null || folderId === undefined) {
       return 'All Files';
     }
-    const folder = resolvedFolders.find((item) => item.id === folderId);
-    return folder?.name ?? 'All Files';
+    const stack: string[] = [];
+    let current = folderId !== null ? folderMap.get(folderId) : undefined;
+    while (current) {
+      stack.unshift(current.name);
+      if (current.parentId === null) {
+        if (canViewAll) {
+          const ownerLabel = current.ownerKey ?? current.ownerEmail ?? current.ownerName ?? `User ${current.ownerId ?? ''}`;
+          stack.unshift(ownerLabel);
+        }
+        break;
+      }
+      const parentId = current.parentId;
+      current = parentId !== null ? folderMap.get(parentId) : undefined;
+    }
+    return stack.length > 0 ? stack.join(' / ') : 'All Files';
+  }, [folderMap, canViewAll]);
+
+  const folderSelectOptions = useMemo(() => {
+    const options: { id: string; label: string }[] = [
+      { id: '', label: 'All Files' }
+    ];
+    const concrete = Array.from(folderMap.values());
+    concrete
+      .sort((a, b) => resolveFolderName(a.id).localeCompare(resolveFolderName(b.id)))
+      .forEach((folder) => {
+        options.push({ id: String(folder.id), label: resolveFolderName(folder.id) });
+      });
+    return options;
+  }, [folderMap, resolveFolderName]);
+
+  const renderFolderOptions = () =>
+    folderSelectOptions.map((option) => (
+      <option key={`folder-${option.id || 'root'}`} value={option.id}>
+        {option.label}
+      </option>
+    ));
+
+  const folderTree = useMemo(() => buildFolderTree(foldersData, currentUserId, canViewAll), [foldersData, currentUserId, canViewAll]);
+
+  const activeOwnerId = useMemo(() => {
+    if (folderFilter !== null) {
+      const folder = folderMap.get(folderFilter);
+      return folder?.ownerId ?? null;
+    }
+    if (canViewAll) {
+      return ownerFilter ?? null;
+    }
+    return currentUserId;
+  }, [folderFilter, folderMap, canViewAll, ownerFilter, currentUserId]);
+
+  const shouldFilterByOwner = useMemo(() => {
+    if (folderFilter !== null) {
+      return true;
+    }
+    if (!canViewAll) {
+      return true;
+    }
+    return ownerFilter !== null;
+  }, [folderFilter, canViewAll, ownerFilter]);
+
+  const visibleFolders = useMemo(() => {
+    const targetParentId = folderFilter ?? null;
+    return foldersData
+      .filter(
+        (folder): folder is GalleryFolder & { id: number } =>
+          folder.id !== null &&
+          (folder.parentId ?? null) === targetParentId &&
+          (!shouldFilterByOwner || (folder.ownerId ?? null) === (activeOwnerId ?? null))
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [foldersData, folderFilter, shouldFilterByOwner, activeOwnerId]);
+
+  const resolveOwnerLabel = useCallback(
+    (ownerId: number | null) => {
+      if (ownerId === null) {
+        return canViewAll ? 'Unassigned' : 'My Drive';
+      }
+      if (!canViewAll && ownerId === currentUserId) {
+        return 'My Drive';
+      }
+      const match = foldersData.find(
+        (candidate): candidate is GalleryFolder & { id: number } => candidate.id !== null && candidate.ownerId === ownerId
+      );
+      return match?.ownerKey ?? match?.ownerEmail ?? match?.ownerName ?? `User ${ownerId}`;
+    },
+    [canViewAll, currentUserId, foldersData]
+  );
+
+  const headerTitle = useMemo(() => {
+    if (folderFilter !== null) {
+      const folder = folderMap.get(folderFilter);
+      return folder?.name ?? 'Folder';
+    }
+    if (canViewAll) {
+      if (ownerFilter !== null) {
+        return `${resolveOwnerLabel(ownerFilter)}'s Drive`;
+      }
+      return 'All Files';
+    }
+    return 'My Drive';
+  }, [folderFilter, folderMap, canViewAll, ownerFilter, resolveOwnerLabel]);
+
+  const headerSubtitle = useMemo(() => {
+    if (folderFilter !== null) {
+      return resolveFolderName(folderFilter);
+    }
+    if (canViewAll) {
+      return ownerFilter !== null ? 'Viewing files for a specific user' : 'Everything that has been uploaded across the workspace';
+    }
+    return 'Quick access to the files and folders you own';
+  }, [folderFilter, resolveFolderName, canViewAll, ownerFilter]);
+
+  const breadcrumbs = useMemo(() => {
+    const crumbs: { label: string; folderId: number | null; ownerId: number | null }[] = [
+      { label: 'All Files', folderId: null, ownerId: null }
+    ];
+
+    if (folderFilter !== null) {
+      const stack: (GalleryFolder & { id: number })[] = [];
+      let current = folderMap.get(folderFilter);
+      const ownerId = current?.ownerId ?? null;
+      while (current) {
+        stack.unshift(current);
+        if (current.parentId === null) {
+          break;
+        }
+        const parentId = current.parentId;
+        current = parentId !== null ? folderMap.get(parentId) : undefined;
+      }
+      if (canViewAll && ownerId !== null) {
+        const ownerLabel = stack[0]?.ownerKey ?? stack[0]?.ownerEmail ?? stack[0]?.ownerName ?? `User ${ownerId}`;
+        crumbs.push({ label: ownerLabel, folderId: null, ownerId });
+      }
+      stack.forEach((folder) => {
+        crumbs.push({ label: folder.name, folderId: folder.id, ownerId: folder.ownerId ?? null });
+      });
+      return crumbs;
+    }
+
+    if (canViewAll && ownerFilter !== null) {
+      const ownerSample = foldersData.find(
+        (folder): folder is GalleryFolder & { id: number } => folder.id !== null && folder.ownerId === ownerFilter
+      );
+      const ownerLabel = ownerSample?.ownerKey ?? ownerSample?.ownerEmail ?? ownerSample?.ownerName ?? `User ${ownerFilter}`;
+      crumbs.push({ label: ownerLabel, folderId: null, ownerId: ownerFilter });
+    }
+
+    return crumbs;
+  }, [folderFilter, ownerFilter, folderMap, foldersData, canViewAll]);
+
+  const handleFolderOpen = (id: number) => {
+    setFolderFilter(id);
+    setOwnerFilter(null);
+    setSelectedIds([]);
   };
 
+  const handleNodeSelection = (node: FolderTreeNode) => {
+    if (node.folderId !== null) {
+      setFolderFilter(node.folderId);
+      setOwnerFilter(null);
+    } else {
+      setOwnerFilter(canViewAll ? node.ownerId ?? null : null);
+      setFolderFilter(null);
+    }
+    setSelectedIds([]);
+  };
+
+  const renderTreeNodes = (nodes: FolderTreeNode[]) =>
+    nodes.map((node) => {
+      const isFolder = node.folderId !== null;
+      const isSelected = isFolder
+        ? folderFilter === node.folderId
+        : folderFilter === null && (canViewAll ? ownerFilter === (node.ownerId ?? null) : isAllScopeSelected);
+      const hasChildren = node.children.length > 0;
+      return (
+        <div key={node.key} className="flex flex-col">
+          <button
+            type="button"
+            onClick={() => handleNodeSelection(node)}
+            className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition ${
+              isSelected ? 'bg-primary/10 text-primary' : 'text-slate-600 hover:bg-slate-100'
+            }`}
+            style={{ paddingLeft: `${node.depth * 12 + 8}px` }}
+          >
+            <span className="flex flex-col">
+              <span className="inline-flex items-center gap-2">
+                <span className="text-lg">{isFolder ? '📁' : '👤'}</span>
+                <span className="font-medium">{node.label}</span>
+              </span>
+              {node.description && <span className="ml-6 text-xs text-slate-400">{node.description}</span>}
+            </span>
+            {hasChildren && <span className="text-xs text-slate-400">{node.children.length}</span>}
+          </button>
+          {hasChildren && <div className="mt-1 flex flex-col gap-1">{renderTreeNodes(node.children)}</div>}
+        </div>
+      );
+    });
+
+  const handleBreadcrumbClick = (folderId: number | null, ownerId: number | null, isLast: boolean) => {
+    if (isLast) {
+      return;
+    }
+    if (folderId !== null) {
+      setFolderFilter(folderId);
+      setOwnerFilter(null);
+    } else if (ownerId !== null) {
+      setOwnerFilter(ownerId);
+      setFolderFilter(null);
+    } else {
+      setOwnerFilter(null);
+      setFolderFilter(null);
+    }
+    setSelectedIds([]);
+  };
+
+  const handleResetSelection = () => {
+    setOwnerFilter(null);
+    setFolderFilter(null);
+    setSelectedIds([]);
+  };
+
+
+  const isAllScopeSelected = folderFilter === null && ownerFilter === null;
+
   const canDelete = canDeleteAll || canDeleteOwn;
+
+  const isLoadingFiles = filesQuery.isFetching;
+
+  const showEmptyState = !visibleFolders.length && !files.length && !isLoadingFiles;
 
   return (
     <div className="space-y-6">
@@ -289,108 +614,167 @@ const GalleryPage = () => {
         disabled={!canUpload || uploadFiles.isPending}
       />
 
-      <div className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <h1 className="text-xl font-semibold text-slate-900">Gallery</h1>
-            <p className="text-sm text-slate-500">Upload, organize, and manage files across your workspace.</p>
-          </div>
-          <div className="flex flex-wrap gap-3">
-            {canUpload && (
-              <button
-                type="button"
-                onClick={handleUploadButtonClick}
-                disabled={uploadFiles.isPending}
-                className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60"
-              >
-                <span className="text-lg">⬆️</span>
-                Upload
-              </button>
-            )}
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <aside className="flex h-full min-h-[26rem] w-full flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm lg:w-72">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-800">Navigation</h2>
             {canUpload && (
               <button
                 type="button"
                 onClick={openFolderModal}
-                className="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-primary hover:text-primary"
+                className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-primary hover:text-primary"
               >
-                <span className="text-lg">📁</span>
-                New Folder
-              </button>
-            )}
-            {canDelete && (
-              <button
-                type="button"
-                onClick={handleDeleteSelected}
-                disabled={!selectedIds.length || deleteFiles.isPending}
-                className="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 shadow-sm transition hover:border-rose-300 hover:bg-rose-100 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
-              >
-                <span className="text-lg">🗑️</span>
-                Delete Selected
+                New
               </button>
             )}
           </div>
-        </div>
+          <button
+            type="button"
+            onClick={handleResetSelection}
+            className={`flex items-center gap-3 rounded-2xl px-3 py-2 text-left text-sm transition ${
+              isAllScopeSelected ? 'bg-primary/10 font-semibold text-primary' : 'text-slate-600 hover:bg-slate-100'
+            }`}
+          >
+            <span className="text-xl">🗂️</span>
+            <span>All files</span>
+          </button>
+          <div className="flex flex-1 flex-col gap-1 overflow-y-auto pr-1">
+            {folderTree.length ? (
+              renderTreeNodes(folderTree)
+            ) : (
+              <p className="px-3 py-6 text-sm text-slate-400">No folders yet. Create one to get started.</p>
+            )}
+          </div>
+        </aside>
 
-        <div className="grid gap-4 lg:grid-cols-4">
-          <div className="lg:col-span-2">
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Search</label>
-            <input
-              type="search"
-              value={searchDraft}
-              onChange={(event) => setSearchDraft(event.target.value)}
-              placeholder="Search by name or extension"
-              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
-            />
-          </div>
-          <div>
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Folder</label>
-            <select
-              value={folderFilter ?? ''}
-              onChange={(event) => {
-                const value = event.target.value;
-                setFolderFilter(value === '' ? null : Number(value));
-              }}
-              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
-            >
-              {renderFolderOptions()}
-            </select>
-          </div>
-          <div>
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Sort by</label>
-            <select
-              value={sortValue}
-              onChange={(event) => setSortValue(event.target.value as SortOptionValue)}
-              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
-            >
-              {SORT_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
+        <div className="flex-1 space-y-6">
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+              <div>
+                <h1 className="text-2xl font-semibold text-slate-900">{headerTitle}</h1>
+                <p className="text-sm text-slate-500">{headerSubtitle}</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                {canUpload && (
+                  <button
+                    type="button"
+                    onClick={handleUploadButtonClick}
+                    disabled={uploadFiles.isPending}
+                    className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-primary/60"
+                  >
+                    <span className="text-lg">⬆️</span>
+                    Upload
+                  </button>
+                )}
+                {canUpload && (
+                  <button
+                    type="button"
+                    onClick={openFolderModal}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-primary hover:text-primary"
+                  >
+                    <span className="text-lg">📁</span>
+                    New folder
+                  </button>
+                )}
+                {canDelete && (
+                  <button
+                    type="button"
+                    onClick={handleDeleteSelected}
+                    disabled={!selectedIds.length || deleteFiles.isPending}
+                    className="inline-flex items-center gap-2 rounded-full border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 shadow-sm transition hover:border-rose-300 hover:bg-rose-100 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                  >
+                    <span className="text-lg">🗑️</span>
+                    Delete selected
+                  </button>
+                )}
+                <div className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 p-1 text-xs font-semibold text-slate-500">
+                  <button
+                    type="button"
+                    onClick={() => setViewMode('grid')}
+                    className={`rounded-full px-3 py-1 transition ${viewMode === 'grid' ? 'bg-white text-primary shadow-sm' : 'hover:text-slate-700'}`}
+                  >
+                    Grid
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setViewMode('list')}
+                    className={`rounded-full px-3 py-1 transition ${viewMode === 'list' ? 'bg-white text-primary shadow-sm' : 'hover:text-slate-700'}`}
+                  >
+                    List
+                  </button>
+                </div>
+              </div>
+            </div>
 
-        {canViewAll && (
-          <div>
-            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Filter by uploader</label>
-            <input
-              type="text"
-              value={uploaderFilter}
-              onChange={(event) => setUploaderFilter(event.target.value)}
-              placeholder="Enter email or name"
-              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
-            />
+            <div className="mt-6 flex flex-col gap-4 lg:flex-row">
+              <div className="flex-1">
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Search in drive</label>
+                <div className="mt-1 flex items-center rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm focus-within:border-primary">
+                  <span className="mr-2 text-lg text-slate-400">🔍</span>
+                  <input
+                    type="search"
+                    value={searchDraft}
+                    onChange={(event) => setSearchDraft(event.target.value)}
+                    placeholder="Search by file name, type, or owner"
+                    className="w-full border-none text-sm outline-none"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+                <div className="sm:w-48">
+                  <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Sort by</label>
+                  <select
+                    value={sortValue}
+                    onChange={(event) => setSortValue(event.target.value as SortOptionValue)}
+                    className="mt-1 w-full rounded-2xl border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+                  >
+                    {SORT_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                {canViewAll && (
+                  <div className="sm:w-64">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Filter by uploader</label>
+                    <input
+                      type="text"
+                      value={uploaderFilter}
+                      onChange={(event) => setUploaderFilter(event.target.value)}
+                      placeholder="Enter email or name"
+                      className="mt-1 w-full rounded-2xl border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
-        )}
-      </div>
 
-      <div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-slate-200 text-sm">
-            <thead className="bg-slate-50">
-              <tr>
-                <th className="w-12 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <nav className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+                {breadcrumbs.map((crumb, index) => {
+                  const isLast = index === breadcrumbs.length - 1;
+                  return (
+                    <div key={`${crumb.label}-${index}`} className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleBreadcrumbClick(crumb.folderId, crumb.ownerId, isLast)}
+                        className={`rounded-full px-3 py-1 transition ${
+                          isLast ? 'bg-primary/10 font-semibold text-primary' : 'hover:bg-slate-100'
+                        }`}
+                        disabled={isLast}
+                      >
+                        {crumb.label}
+                      </button>
+                      {!isLast && <span className="text-slate-300">›</span>}
+                    </div>
+                  );
+                })}
+              </nav>
+              {files.length > 0 && (
+                <label className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
                   <input
                     type="checkbox"
                     checked={allSelected}
@@ -401,130 +785,279 @@ const GalleryPage = () => {
                     }}
                     onChange={toggleSelectAll}
                   />
-                </th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">File</th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Size</th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Folder</th>
-                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Uploaded</th>
-                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-200">
-              {files.map((file) => {
-                const isOwner = currentUserId !== null && currentUserId === (file.uploadedById ?? null);
-                const canDeleteFile = canDeleteAll || (canDeleteOwn && isOwner);
-                return (
-                  <tr key={file.id} className="hover:bg-slate-50/60">
-                    <td className="px-4 py-3">
-                      <input
-                        type="checkbox"
-                        checked={selectedIds.includes(file.id)}
-                        onChange={() => toggleSelect(file.id)}
-                      />
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-xs font-semibold uppercase text-slate-600">
-                          {file.extension.slice(0, 4)}
-                        </div>
-                        <div>
-                          <div className="font-medium text-slate-800">{file.displayName}</div>
-                          <div className="text-xs text-slate-500">{file.originalFilename}</div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-slate-600">{file.extension.toUpperCase()}</td>
-                    <td className="px-4 py-3 text-slate-600">{formatFileSize(file.sizeBytes)}</td>
-                    <td className="px-4 py-3 text-slate-600">{resolveFolderName(file.folderId)}</td>
-                    <td className="px-4 py-3 text-slate-600">
-                      <div className="flex flex-col">
-                        <span>{file.uploadedByName ?? file.uploadedByEmail ?? '—'}</span>
-                        <span className="text-xs text-slate-400">{formatDateTime(file.uploadedAt)}</span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center justify-end gap-3">
-                        <a
-                          href={resolveFileUrl(file.id)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-sm font-semibold text-primary hover:text-primary/80"
-                        >
-                          View
-                        </a>
-                        {canEdit && (
-                          <button
-                            type="button"
-                            onClick={() => openEditModal(file)}
-                            className="text-sm font-semibold text-slate-600 hover:text-primary"
-                          >
-                            Edit
-                          </button>
-                        )}
-                        {canDeleteFile && (
-                          <button
-                            type="button"
-                            onClick={() => handleDeleteSingle(file.id)}
-                            className="text-sm font-semibold text-rose-600 hover:text-rose-500"
-                          >
-                            Delete
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-              {!files.length && (
-                <tr>
-                  <td colSpan={7} className="px-4 py-16 text-center text-sm text-slate-500">
-                    {filesQuery.isFetching ? 'Loading files…' : 'No files found for the selected filters.'}
-                  </td>
-                </tr>
+                  Select all
+                </label>
               )}
-            </tbody>
-          </table>
-        </div>
-        <div className="flex flex-col gap-4 border-t border-slate-200 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3 text-sm text-slate-600">
-            <span>Rows per page</span>
-            <select
-              value={pageSize}
-              onChange={(event) => setPageSize(Number(event.target.value))}
-              className="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
-            >
-              {PAGE_SIZE_OPTIONS.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
+            </div>
+
+            {visibleFolders.length > 0 && (
+              <div className="mt-6">
+                <h2 className="mb-3 text-sm font-semibold text-slate-700">Folders</h2>
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+                  {visibleFolders.map((folder) => (
+                    <button
+                      key={folder.id}
+                      type="button"
+                      onClick={() => handleFolderOpen(folder.id)}
+                      className="group flex h-full flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-left transition hover:border-primary hover:bg-white hover:shadow-md"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-3xl">📁</span>
+                        <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-500 shadow-sm">
+                          {resolveOwnerLabel(folder.ownerId ?? null)}
+                        </span>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-slate-900">{folder.name}</p>
+                        <p className="truncate text-xs text-slate-500">{folder.path}</p>
+                      </div>
+                      <span className="text-xs font-semibold text-primary opacity-0 transition group-hover:opacity-100">
+                        Open folder →
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="mt-6">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-sm font-semibold text-slate-700">Files</h2>
+                <span className="text-xs uppercase tracking-wide text-slate-400">
+                  {files.length} item{files.length === 1 ? '' : 's'}
+                </span>
+              </div>
+
+              {viewMode === 'grid' ? (
+                <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+                  {files.map((file) => {
+                    const isOwner = currentUserId !== null && currentUserId === (file.uploadedById ?? null);
+                    const canDeleteFile = canDeleteAll || (canDeleteOwn && isOwner);
+                    const isSelected = selectedIds.includes(file.id);
+                    return (
+                      <div
+                        key={file.id}
+                        className={`group relative flex h-full flex-col justify-between rounded-2xl border bg-white p-4 transition hover:shadow-lg ${
+                          isSelected ? 'border-primary ring-2 ring-primary/20' : 'border-slate-200'
+                        }`}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex min-w-0 items-center gap-3">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-sm font-semibold uppercase text-primary">
+                              {file.extension.slice(0, 4)}
+                            </div>
+                            <div className="min-w-0">
+                              <p className="truncate text-sm font-semibold text-slate-900">{file.displayName}</p>
+                              <p className="truncate text-xs text-slate-500">{file.originalFilename}</p>
+                            </div>
+                          </div>
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => toggleSelect(file.id)}
+                            className="mt-1"
+                          />
+                        </div>
+                        <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500">
+                          <span>{formatFileSize(file.sizeBytes)}</span>
+                          <span>•</span>
+                          <span>{file.extension.toUpperCase()}</span>
+                          <span>•</span>
+                          <span className="truncate">{resolveFolderName(file.folderId)}</span>
+                        </div>
+                        <div className="mt-4 flex items-end justify-between gap-3 text-xs text-slate-500">
+                          <div className="flex flex-col">
+                            <span className="truncate">{file.uploadedByName ?? file.uploadedByEmail ?? '—'}</span>
+                            <span>{formatDateTime(file.uploadedAt)}</span>
+                          </div>
+                          <div className="flex items-center gap-3 text-sm font-semibold">
+                            <a
+                              href={resolveFileUrl(file.id)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-primary hover:text-primary/80"
+                            >
+                              Open
+                            </a>
+                            {canEdit && (
+                              <button
+                                type="button"
+                                onClick={() => openEditModal(file)}
+                                className="text-slate-600 hover:text-primary"
+                              >
+                                Rename
+                              </button>
+                            )}
+                            {canDeleteFile && (
+                              <button
+                                type="button"
+                                onClick={() => handleDeleteSingle(file.id)}
+                                className="text-rose-600 hover:text-rose-500"
+                              >
+                                Delete
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {!files.length && (
+                    <div className="col-span-full flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-slate-200 bg-slate-50/50 p-12 text-center text-sm text-slate-500">
+                      {isLoadingFiles ? 'Loading files…' : 'Drop files here or use the upload button to get started.'}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="mt-4 overflow-x-auto">
+                  <table className="min-w-full divide-y divide-slate-200 text-sm">
+                    <thead className="bg-slate-50">
+                      <tr>
+                        <th className="w-12 px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                          <input
+                            type="checkbox"
+                            checked={allSelected}
+                            ref={(element) => {
+                              if (element) {
+                                element.indeterminate = partiallySelected;
+                              }
+                            }}
+                            onChange={toggleSelectAll}
+                          />
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">File</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Type</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Size</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Folder</th>
+                        <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">Uploaded</th>
+                        <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-200">
+                      {files.map((file) => {
+                        const isOwner = currentUserId !== null && currentUserId === (file.uploadedById ?? null);
+                        const canDeleteFile = canDeleteAll || (canDeleteOwn && isOwner);
+                        return (
+                          <tr key={file.id} className="hover:bg-slate-50/60">
+                            <td className="px-4 py-3">
+                              <input
+                                type="checkbox"
+                                checked={selectedIds.includes(file.id)}
+                                onChange={() => toggleSelect(file.id)}
+                              />
+                            </td>
+                            <td className="px-4 py-3">
+                              <div className="flex items-center gap-3">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-xs font-semibold uppercase text-slate-600">
+                                  {file.extension.slice(0, 4)}
+                                </div>
+                                <div>
+                                  <div className="font-medium text-slate-800">{file.displayName}</div>
+                                  <div className="text-xs text-slate-500">{file.originalFilename}</div>
+                                </div>
+                              </div>
+                            </td>
+                            <td className="px-4 py-3 text-slate-600">{file.extension.toUpperCase()}</td>
+                            <td className="px-4 py-3 text-slate-600">{formatFileSize(file.sizeBytes)}</td>
+                            <td className="px-4 py-3 text-slate-600">{resolveFolderName(file.folderId)}</td>
+                            <td className="px-4 py-3 text-slate-600">
+                              <div className="flex flex-col">
+                                <span>{file.uploadedByName ?? file.uploadedByEmail ?? '—'}</span>
+                                <span className="text-xs text-slate-400">{formatDateTime(file.uploadedAt)}</span>
+                              </div>
+                            </td>
+                            <td className="px-4 py-3">
+                              <div className="flex items-center justify-end gap-3">
+                                <a
+                                  href={resolveFileUrl(file.id)}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-sm font-semibold text-primary hover:text-primary/80"
+                                >
+                                  Open
+                                </a>
+                                {canEdit && (
+                                  <button
+                                    type="button"
+                                    onClick={() => openEditModal(file)}
+                                    className="text-sm font-semibold text-slate-600 hover:text-primary"
+                                  >
+                                    Rename
+                                  </button>
+                                )}
+                                {canDeleteFile && (
+                                  <button
+                                    type="button"
+                                    onClick={() => handleDeleteSingle(file.id)}
+                                    className="text-sm font-semibold text-rose-600 hover:text-rose-500"
+                                  >
+                                    Delete
+                                  </button>
+                                )}
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                      {!files.length && (
+                        <tr>
+                          <td colSpan={7} className="px-4 py-16 text-center text-sm text-slate-500">
+                            {isLoadingFiles ? 'Loading files…' : 'No files found for the selected filters.'}
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+
+            <div className="mt-6 flex flex-col gap-4 border-t border-slate-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3 text-sm text-slate-600">
+                <span>Rows per page</span>
+                <select
+                  value={pageSize}
+                  onChange={(event) => setPageSize(Number(event.target.value))}
+                  className="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+                >
+                  {PAGE_SIZE_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex items-center gap-4 text-sm text-slate-600">
+                <button
+                  type="button"
+                  onClick={() => setPage((previous) => Math.max(previous - 1, 0))}
+                  disabled={page === 0}
+                  className="rounded-lg border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                >
+                  Previous
+                </button>
+                <span>
+                  Page {Math.min(page + 1, totalPages || 1)} of {totalPages || 1}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage((previous) => (previous + 1 < totalPages ? previous + 1 : previous))}
+                  disabled={page + 1 >= totalPages}
+                  className="rounded-lg border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
           </div>
-          <div className="flex items-center gap-4 text-sm text-slate-600">
-            <button
-              type="button"
-              onClick={() => setPage((previous) => Math.max(previous - 1, 0))}
-              disabled={page === 0}
-              className="rounded-lg border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
-            >
-              Previous
-            </button>
-            <span>
-              Page {Math.min(page + 1, totalPages || 1)} of {totalPages || 1}
-            </span>
-            <button
-              type="button"
-              onClick={() => setPage((previous) => (previous + 1 < totalPages ? previous + 1 : previous))}
-              disabled={page + 1 >= totalPages}
-              className="rounded-lg border border-slate-300 px-3 py-1 font-semibold text-slate-700 transition hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
-            >
-              Next
-            </button>
-          </div>
+
+          {showEmptyState && (
+            <div className="rounded-3xl border-2 border-dashed border-slate-200 bg-slate-50 p-12 text-center text-sm text-slate-500">
+              Nothing to show here yet. Create a folder or upload a file to start building your drive.
+            </div>
+          )}
         </div>
       </div>
-
       {editModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4">
           <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">

--- a/frontend/src/types/gallery.ts
+++ b/frontend/src/types/gallery.ts
@@ -21,6 +21,10 @@ export interface GalleryFolder {
   path: string;
   parentId: number | null;
   root: boolean;
+  ownerId: number | null;
+  ownerName?: string | null;
+  ownerEmail?: string | null;
+  ownerKey?: string | null;
 }
 
 export type GalleryFilePage = Pagination<GalleryFile>;


### PR DESCRIPTION
## Summary
- enforce per-user gallery folder ownership with a new migration and service updates
- redesign the gallery page with a Google Drive-inspired interface including grid/list views and owner-aware folder tiles
- route direct permission override saves through the dedicated permissions endpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e53ae15da08323b4ff14c896223097