### PR TITLE
Fix gallery navigation and preview authentication issues

### DIFF
--- a/backend/src/main/java/com/example/rbac/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/rbac/config/JwtAuthenticationFilter.java
@@ -30,9 +30,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (header != null && header.startsWith("Bearer ")) {
-            String token = header.substring(7);
+        String token = resolveToken(request);
+        if (token != null) {
             try {
                 Claims claims = jwtService.parseToken(token);
                 if (SecurityContextHolder.getContext().getAuthentication() == null) {
@@ -47,5 +46,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         }
         filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String candidate = header.substring(7).trim();
+            if (!candidate.isEmpty()) {
+                return candidate;
+            }
+        }
+        String accessToken = request.getParameter("access_token");
+        if (accessToken != null && !accessToken.isBlank()) {
+            return accessToken;
+        }
+        String token = request.getParameter("token");
+        if (token != null && !token.isBlank()) {
+            return token;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- restructure the gallery tree to surface "My Files" and "All Users Files" groupings, refresh labels, and merge the grid layout into a single item section
- reuse an access-token aware URL helper across grid, list, and detail views so image previews and modal content load correctly
- let the JWT filter recognise tokens passed via query parameters to keep file previews and "open in new tab" requests authenticated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6676ba4308323bd9362ff9e319b2c