### PR TITLE
Fix blog post listing loading state

### DIFF
--- a/backend/src/main/java/com/example/rbac/blog/controller/BlogCategoryController.java
+++ b/backend/src/main/java/com/example/rbac/blog/controller/BlogCategoryController.java
@@ -1,0 +1,60 @@
+package com.example.rbac.blog.controller;
+
+import com.example.rbac.blog.dto.BlogCategoryDto;
+import com.example.rbac.blog.dto.BlogCategoryRequest;
+import com.example.rbac.blog.service.BlogCategoryService;
+import com.example.rbac.common.pagination.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/blog/categories")
+public class BlogCategoryController {
+
+    private final BlogCategoryService blogCategoryService;
+
+    public BlogCategoryController(BlogCategoryService blogCategoryService) {
+        this.blogCategoryService = blogCategoryService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('BLOG_CATEGORY_VIEW')")
+    public PageResponse<BlogCategoryDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                              @RequestParam(name = "size", defaultValue = "20") int size,
+                                              @RequestParam(name = "search", required = false) String search) {
+        return blogCategoryService.list(page, size, search);
+    }
+
+    @GetMapping("/all")
+    @PreAuthorize("hasAuthority('BLOG_CATEGORY_VIEW')")
+    public List<BlogCategoryDto> findAll() {
+        return blogCategoryService.findAll();
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('BLOG_CATEGORY_VIEW')")
+    public BlogCategoryDto get(@PathVariable("id") Long id) {
+        return blogCategoryService.get(id);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('BLOG_CATEGORY_CREATE')")
+    public BlogCategoryDto create(@Valid @RequestBody BlogCategoryRequest request) {
+        return blogCategoryService.create(request);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('BLOG_CATEGORY_UPDATE')")
+    public BlogCategoryDto update(@PathVariable("id") Long id, @Valid @RequestBody BlogCategoryRequest request) {
+        return blogCategoryService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('BLOG_CATEGORY_DELETE')")
+    public void delete(@PathVariable("id") Long id) {
+        blogCategoryService.delete(id);
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/controller/BlogMediaController.java
+++ b/backend/src/main/java/com/example/rbac/blog/controller/BlogMediaController.java
@@ -1,0 +1,67 @@
+package com.example.rbac.blog.controller;
+
+import com.example.rbac.blog.dto.BlogMediaUploadResponse;
+import com.example.rbac.blog.service.BlogMediaStorageService;
+import com.example.rbac.common.exception.ApiException;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/v1/blog/media")
+public class BlogMediaController {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            MediaType.IMAGE_JPEG_VALUE,
+            MediaType.IMAGE_PNG_VALUE,
+            "image/webp",
+            MediaType.IMAGE_GIF_VALUE,
+            "image/svg+xml"
+    );
+
+    private final BlogMediaStorageService blogMediaStorageService;
+
+    public BlogMediaController(BlogMediaStorageService blogMediaStorageService) {
+        this.blogMediaStorageService = blogMediaStorageService;
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('BLOG_POST_CREATE','BLOG_POST_UPDATE')")
+    public BlogMediaUploadResponse upload(@RequestParam("file") MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "File is required");
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase())) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Unsupported media type");
+        }
+        String key = blogMediaStorageService.store(file);
+        String url = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/v1/blog/media/")
+                .path(key)
+                .toUriString();
+        return new BlogMediaUploadResponse(key, url);
+    }
+
+    @GetMapping("/{key}")
+    public ResponseEntity<Resource> load(@PathVariable("key") String key) throws IOException {
+        Resource resource = blogMediaStorageService.load(key);
+        String contentType = Files.probeContentType(resource.getFile().toPath());
+        if (contentType == null) {
+            contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        }
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_TYPE, contentType)
+                .body(resource);
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/controller/BlogPostController.java
+++ b/backend/src/main/java/com/example/rbac/blog/controller/BlogPostController.java
@@ -1,0 +1,56 @@
+package com.example.rbac.blog.controller;
+
+import com.example.rbac.blog.dto.BlogPostDto;
+import com.example.rbac.blog.dto.BlogPostRequest;
+import com.example.rbac.blog.service.BlogPostService;
+import com.example.rbac.common.pagination.PageResponse;
+import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/blog/posts")
+public class BlogPostController {
+
+    private final BlogPostService blogPostService;
+
+    public BlogPostController(BlogPostService blogPostService) {
+        this.blogPostService = blogPostService;
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('BLOG_POST_VIEW')")
+    public PageResponse<BlogPostDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                          @RequestParam(name = "size", defaultValue = "20") int size,
+                                          @RequestParam(name = "sort", required = false) String sort,
+                                          @RequestParam(name = "direction", required = false) String direction,
+                                          @RequestParam(name = "categoryId", required = false) Long categoryId,
+                                          @RequestParam(name = "published", required = false) Boolean published,
+                                          @RequestParam(name = "search", required = false) String search) {
+        return blogPostService.list(page, size, sort, direction, categoryId, published, search);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('BLOG_POST_VIEW')")
+    public BlogPostDto get(@PathVariable("id") Long id) {
+        return blogPostService.get(id);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('BLOG_POST_CREATE')")
+    public BlogPostDto create(@Valid @RequestBody BlogPostRequest request) {
+        return blogPostService.create(request);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('BLOG_POST_UPDATE')")
+    public BlogPostDto update(@PathVariable("id") Long id, @Valid @RequestBody BlogPostRequest request) {
+        return blogPostService.update(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('BLOG_POST_DELETE')")
+    public void delete(@PathVariable("id") Long id) {
+        blogPostService.delete(id);
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/controller/PublicBlogController.java
+++ b/backend/src/main/java/com/example/rbac/blog/controller/PublicBlogController.java
@@ -1,0 +1,41 @@
+package com.example.rbac.blog.controller;
+
+import com.example.rbac.blog.dto.BlogCategoryDto;
+import com.example.rbac.blog.dto.PublicBlogPostDto;
+import com.example.rbac.blog.service.BlogCategoryService;
+import com.example.rbac.blog.service.BlogPostService;
+import com.example.rbac.common.pagination.PageResponse;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/blog/public")
+public class PublicBlogController {
+
+    private final BlogPostService blogPostService;
+    private final BlogCategoryService blogCategoryService;
+
+    public PublicBlogController(BlogPostService blogPostService, BlogCategoryService blogCategoryService) {
+        this.blogPostService = blogPostService;
+        this.blogCategoryService = blogCategoryService;
+    }
+
+    @GetMapping("/posts")
+    public PageResponse<PublicBlogPostDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                                @RequestParam(name = "size", defaultValue = "12") int size,
+                                                @RequestParam(name = "category", required = false) String categorySlug,
+                                                @RequestParam(name = "search", required = false) String search) {
+        return blogPostService.listPublished(page, size, categorySlug, search);
+    }
+
+    @GetMapping("/posts/{slug}")
+    public PublicBlogPostDto get(@PathVariable("slug") String slug) {
+        return blogPostService.getPublishedPost(slug);
+    }
+
+    @GetMapping("/categories")
+    public List<BlogCategoryDto> categories() {
+        return blogCategoryService.findAll();
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/dto/BlogCategoryDto.java
+++ b/backend/src/main/java/com/example/rbac/blog/dto/BlogCategoryDto.java
@@ -1,0 +1,61 @@
+package com.example.rbac.blog.dto;
+
+import java.time.Instant;
+
+public class BlogCategoryDto {
+
+    private Long id;
+    private String name;
+    private String slug;
+    private String description;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/dto/BlogCategoryRequest.java
+++ b/backend/src/main/java/com/example/rbac/blog/dto/BlogCategoryRequest.java
@@ -1,0 +1,40 @@
+package com.example.rbac.blog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class BlogCategoryRequest {
+
+    @NotBlank
+    @Size(max = 150)
+    private String name;
+
+    @Size(max = 160)
+    private String slug;
+
+    private String description;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/dto/BlogMediaUploadResponse.java
+++ b/backend/src/main/java/com/example/rbac/blog/dto/BlogMediaUploadResponse.java
@@ -1,0 +1,31 @@
+package com.example.rbac.blog.dto;
+
+public class BlogMediaUploadResponse {
+
+    private String key;
+    private String url;
+
+    public BlogMediaUploadResponse() {
+    }
+
+    public BlogMediaUploadResponse(String key, String url) {
+        this.key = key;
+        this.url = url;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/dto/BlogPostDto.java
+++ b/backend/src/main/java/com/example/rbac/blog/dto/BlogPostDto.java
@@ -1,0 +1,142 @@
+package com.example.rbac.blog.dto;
+
+import java.time.Instant;
+
+public class BlogPostDto {
+
+    private Long id;
+    private Long categoryId;
+    private String categoryName;
+    private String title;
+    private String slug;
+    private String description;
+    private String bannerImage;
+    private String metaTitle;
+    private String metaDescription;
+    private String metaKeywords;
+    private String metaImage;
+    private boolean published;
+    private Instant publishedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBannerImage() {
+        return bannerImage;
+    }
+
+    public void setBannerImage(String bannerImage) {
+        this.bannerImage = bannerImage;
+    }
+
+    public String getMetaTitle() {
+        return metaTitle;
+    }
+
+    public void setMetaTitle(String metaTitle) {
+        this.metaTitle = metaTitle;
+    }
+
+    public String getMetaDescription() {
+        return metaDescription;
+    }
+
+    public void setMetaDescription(String metaDescription) {
+        this.metaDescription = metaDescription;
+    }
+
+    public String getMetaKeywords() {
+        return metaKeywords;
+    }
+
+    public void setMetaKeywords(String metaKeywords) {
+        this.metaKeywords = metaKeywords;
+    }
+
+    public String getMetaImage() {
+        return metaImage;
+    }
+
+    public void setMetaImage(String metaImage) {
+        this.metaImage = metaImage;
+    }
+
+    public boolean isPublished() {
+        return published;
+    }
+
+    public void setPublished(boolean published) {
+        this.published = published;
+    }
+
+    public Instant getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(Instant publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/dto/BlogPostRequest.java
+++ b/backend/src/main/java/com/example/rbac/blog/dto/BlogPostRequest.java
@@ -1,0 +1,108 @@
+package com.example.rbac.blog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class BlogPostRequest {
+
+    @NotNull
+    private Long categoryId;
+
+    @NotBlank
+    @Size(max = 200)
+    private String title;
+
+    @Size(max = 210)
+    private String slug;
+
+    @NotBlank
+    private String description;
+
+    private String bannerImage;
+    private String metaTitle;
+    private String metaDescription;
+    private String metaKeywords;
+    private String metaImage;
+    private boolean published;
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBannerImage() {
+        return bannerImage;
+    }
+
+    public void setBannerImage(String bannerImage) {
+        this.bannerImage = bannerImage;
+    }
+
+    public String getMetaTitle() {
+        return metaTitle;
+    }
+
+    public void setMetaTitle(String metaTitle) {
+        this.metaTitle = metaTitle;
+    }
+
+    public String getMetaDescription() {
+        return metaDescription;
+    }
+
+    public void setMetaDescription(String metaDescription) {
+        this.metaDescription = metaDescription;
+    }
+
+    public String getMetaKeywords() {
+        return metaKeywords;
+    }
+
+    public void setMetaKeywords(String metaKeywords) {
+        this.metaKeywords = metaKeywords;
+    }
+
+    public String getMetaImage() {
+        return metaImage;
+    }
+
+    public void setMetaImage(String metaImage) {
+        this.metaImage = metaImage;
+    }
+
+    public boolean isPublished() {
+        return published;
+    }
+
+    public void setPublished(boolean published) {
+        this.published = published;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/dto/PublicBlogPostDto.java
+++ b/backend/src/main/java/com/example/rbac/blog/dto/PublicBlogPostDto.java
@@ -1,0 +1,97 @@
+package com.example.rbac.blog.dto;
+
+import java.time.Instant;
+
+public class PublicBlogPostDto {
+
+    private String title;
+    private String slug;
+    private String description;
+    private String bannerImage;
+    private String metaTitle;
+    private String metaDescription;
+    private String metaKeywords;
+    private String metaImage;
+    private String category;
+    private Instant publishedAt;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBannerImage() {
+        return bannerImage;
+    }
+
+    public void setBannerImage(String bannerImage) {
+        this.bannerImage = bannerImage;
+    }
+
+    public String getMetaTitle() {
+        return metaTitle;
+    }
+
+    public void setMetaTitle(String metaTitle) {
+        this.metaTitle = metaTitle;
+    }
+
+    public String getMetaDescription() {
+        return metaDescription;
+    }
+
+    public void setMetaDescription(String metaDescription) {
+        this.metaDescription = metaDescription;
+    }
+
+    public String getMetaKeywords() {
+        return metaKeywords;
+    }
+
+    public void setMetaKeywords(String metaKeywords) {
+        this.metaKeywords = metaKeywords;
+    }
+
+    public String getMetaImage() {
+        return metaImage;
+    }
+
+    public void setMetaImage(String metaImage) {
+        this.metaImage = metaImage;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public Instant getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(Instant publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/mapper/BlogCategoryMapper.java
+++ b/backend/src/main/java/com/example/rbac/blog/mapper/BlogCategoryMapper.java
@@ -1,0 +1,11 @@
+package com.example.rbac.blog.mapper;
+
+import com.example.rbac.blog.dto.BlogCategoryDto;
+import com.example.rbac.blog.model.BlogCategory;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface BlogCategoryMapper {
+
+    BlogCategoryDto toDto(BlogCategory category);
+}

--- a/backend/src/main/java/com/example/rbac/blog/mapper/BlogPostMapper.java
+++ b/backend/src/main/java/com/example/rbac/blog/mapper/BlogPostMapper.java
@@ -1,0 +1,18 @@
+package com.example.rbac.blog.mapper;
+
+import com.example.rbac.blog.dto.BlogPostDto;
+import com.example.rbac.blog.dto.PublicBlogPostDto;
+import com.example.rbac.blog.model.BlogPost;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface BlogPostMapper {
+
+    @Mapping(target = "categoryId", source = "category.id")
+    @Mapping(target = "categoryName", source = "category.name")
+    BlogPostDto toDto(BlogPost post);
+
+    @Mapping(target = "category", source = "category.name")
+    PublicBlogPostDto toPublicDto(BlogPost post);
+}

--- a/backend/src/main/java/com/example/rbac/blog/model/BlogCategory.java
+++ b/backend/src/main/java/com/example/rbac/blog/model/BlogCategory.java
@@ -1,0 +1,120 @@
+package com.example.rbac.blog.model;
+
+import jakarta.persistence.*;
+
+import java.text.Normalizer;
+import java.time.Instant;
+import java.util.Locale;
+
+@Entity
+@Table(name = "blog_categories")
+public class BlogCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(nullable = false, length = 160, unique = true)
+    private String slug;
+
+    @Column(columnDefinition = "text")
+    private String description;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+        sanitize();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+        sanitize();
+    }
+
+    private void sanitize() {
+        name = name == null ? null : name.trim();
+        if (name == null || name.isEmpty()) {
+            throw new IllegalStateException("Category name cannot be blank");
+        }
+        if (slug == null || slug.isBlank()) {
+            slug = buildSlug(name);
+        } else {
+            slug = buildSlug(slug);
+        }
+        if (description != null) {
+            description = description.trim();
+        }
+    }
+
+    private String buildSlug(String source) {
+        String normalized = Normalizer.normalize(source, Normalizer.Form.NFD)
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        String cleaned = normalized.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9\\s-_]", "");
+        cleaned = cleaned.trim().replaceAll("[\\s-_]+", "-");
+        if (cleaned.isEmpty()) {
+            cleaned = "category" + Long.toHexString(System.nanoTime());
+        }
+        return cleaned.length() > 150 ? cleaned.substring(0, 150) : cleaned;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/model/BlogPost.java
+++ b/backend/src/main/java/com/example/rbac/blog/model/BlogPost.java
@@ -1,0 +1,227 @@
+package com.example.rbac.blog.model;
+
+import jakarta.persistence.*;
+
+import java.text.Normalizer;
+import java.time.Instant;
+import java.util.Locale;
+
+@Entity
+@Table(name = "blog_posts")
+public class BlogPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "category_id", nullable = false)
+    private BlogCategory category;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 210, unique = true)
+    private String slug;
+
+    @Column(columnDefinition = "text", nullable = false)
+    private String description;
+
+    @Column(name = "banner_image", length = 255)
+    private String bannerImage;
+
+    @Column(name = "meta_title", length = 200)
+    private String metaTitle;
+
+    @Column(name = "meta_description", columnDefinition = "text")
+    private String metaDescription;
+
+    @Column(name = "meta_keywords", columnDefinition = "text")
+    private String metaKeywords;
+
+    @Column(name = "meta_image", length = 255)
+    private String metaImage;
+
+    @Column(nullable = false)
+    private boolean published = false;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+        sanitize();
+        if (published && publishedAt == null) {
+            publishedAt = now;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+        sanitize();
+        if (published && publishedAt == null) {
+            publishedAt = Instant.now();
+        }
+        if (!published) {
+            publishedAt = null;
+        }
+    }
+
+    private void sanitize() {
+        title = title == null ? null : title.trim();
+        if (title == null || title.isEmpty()) {
+            throw new IllegalStateException("Post title cannot be blank");
+        }
+        if (slug == null || slug.isBlank()) {
+            slug = buildSlug(title);
+        } else {
+            slug = buildSlug(slug);
+        }
+        if (description == null || description.isBlank()) {
+            throw new IllegalStateException("Post description cannot be blank");
+        }
+        if (metaTitle != null) {
+            metaTitle = metaTitle.trim();
+        }
+        if (metaDescription != null) {
+            metaDescription = metaDescription.trim();
+        }
+        if (metaKeywords != null) {
+            metaKeywords = metaKeywords.trim();
+        }
+    }
+
+    private String buildSlug(String source) {
+        String normalized = Normalizer.normalize(source, Normalizer.Form.NFD)
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        String cleaned = normalized.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9\\s-_]", "");
+        cleaned = cleaned.trim().replaceAll("[\\s-_]+", "-");
+        if (cleaned.isEmpty()) {
+            cleaned = "post" + Long.toHexString(System.nanoTime());
+        }
+        return cleaned.length() > 200 ? cleaned.substring(0, 200) : cleaned;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public BlogCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(BlogCategory category) {
+        this.category = category;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBannerImage() {
+        return bannerImage;
+    }
+
+    public void setBannerImage(String bannerImage) {
+        this.bannerImage = bannerImage;
+    }
+
+    public String getMetaTitle() {
+        return metaTitle;
+    }
+
+    public void setMetaTitle(String metaTitle) {
+        this.metaTitle = metaTitle;
+    }
+
+    public String getMetaDescription() {
+        return metaDescription;
+    }
+
+    public void setMetaDescription(String metaDescription) {
+        this.metaDescription = metaDescription;
+    }
+
+    public String getMetaKeywords() {
+        return metaKeywords;
+    }
+
+    public void setMetaKeywords(String metaKeywords) {
+        this.metaKeywords = metaKeywords;
+    }
+
+    public String getMetaImage() {
+        return metaImage;
+    }
+
+    public void setMetaImage(String metaImage) {
+        this.metaImage = metaImage;
+    }
+
+    public boolean isPublished() {
+        return published;
+    }
+
+    public void setPublished(boolean published) {
+        this.published = published;
+    }
+
+    public Instant getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(Instant publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/repository/BlogCategoryRepository.java
+++ b/backend/src/main/java/com/example/rbac/blog/repository/BlogCategoryRepository.java
@@ -1,0 +1,19 @@
+package com.example.rbac.blog.repository;
+
+import com.example.rbac.blog.model.BlogCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BlogCategoryRepository extends JpaRepository<BlogCategory, Long> {
+
+    Optional<BlogCategory> findBySlugIgnoreCase(String slug);
+
+    boolean existsBySlugIgnoreCase(String slug);
+
+    boolean existsBySlugIgnoreCaseAndIdNot(String slug, Long id);
+
+    Page<BlogCategory> findByNameContainingIgnoreCase(String name, Pageable pageable);
+}

--- a/backend/src/main/java/com/example/rbac/blog/repository/BlogPostRepository.java
+++ b/backend/src/main/java/com/example/rbac/blog/repository/BlogPostRepository.java
@@ -1,0 +1,26 @@
+package com.example.rbac.blog.repository;
+
+import com.example.rbac.blog.model.BlogPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.Optional;
+
+public interface BlogPostRepository extends JpaRepository<BlogPost, Long>, JpaSpecificationExecutor<BlogPost> {
+
+    Optional<BlogPost> findBySlugIgnoreCase(String slug);
+
+    boolean existsBySlugIgnoreCase(String slug);
+
+    boolean existsBySlugIgnoreCaseAndIdNot(String slug, Long id);
+
+    long countByCategoryId(Long categoryId);
+
+    @Override
+    @EntityGraph(attributePaths = "category")
+    Page<BlogPost> findAll(Specification<BlogPost> spec, Pageable pageable);
+}

--- a/backend/src/main/java/com/example/rbac/blog/service/BlogCategoryService.java
+++ b/backend/src/main/java/com/example/rbac/blog/service/BlogCategoryService.java
@@ -1,0 +1,147 @@
+package com.example.rbac.blog.service;
+
+import com.example.rbac.activity.service.ActivityRecorder;
+import com.example.rbac.blog.dto.BlogCategoryDto;
+import com.example.rbac.blog.dto.BlogCategoryRequest;
+import com.example.rbac.blog.mapper.BlogCategoryMapper;
+import com.example.rbac.blog.model.BlogCategory;
+import com.example.rbac.blog.repository.BlogCategoryRepository;
+import com.example.rbac.blog.repository.BlogPostRepository;
+import com.example.rbac.common.exception.ApiException;
+import com.example.rbac.common.pagination.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class BlogCategoryService {
+
+    private final BlogCategoryRepository blogCategoryRepository;
+    private final BlogPostRepository blogPostRepository;
+    private final BlogCategoryMapper blogCategoryMapper;
+    private final ActivityRecorder activityRecorder;
+
+    public BlogCategoryService(BlogCategoryRepository blogCategoryRepository,
+                               BlogPostRepository blogPostRepository,
+                               BlogCategoryMapper blogCategoryMapper,
+                               ActivityRecorder activityRecorder) {
+        this.blogCategoryRepository = blogCategoryRepository;
+        this.blogPostRepository = blogPostRepository;
+        this.blogCategoryMapper = blogCategoryMapper;
+        this.activityRecorder = activityRecorder;
+    }
+
+    public PageResponse<BlogCategoryDto> list(int page, int size, String search) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.max(size, 1), Sort.by(Sort.Direction.ASC, "name"));
+        Page<BlogCategory> result;
+        if (search != null && !search.isBlank()) {
+            result = blogCategoryRepository.findByNameContainingIgnoreCase(search.trim(), pageable);
+        } else {
+            result = blogCategoryRepository.findAll(pageable);
+        }
+        return PageResponse.from(result.map(blogCategoryMapper::toDto));
+    }
+
+    public List<BlogCategoryDto> findAll() {
+        return blogCategoryRepository.findAll(Sort.by(Sort.Direction.ASC, "name"))
+                .stream()
+                .map(blogCategoryMapper::toDto)
+                .toList();
+    }
+
+    public BlogCategoryDto get(Long id) {
+        BlogCategory category = blogCategoryRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Category not found"));
+        return blogCategoryMapper.toDto(category);
+    }
+
+    @Transactional
+    public BlogCategoryDto create(BlogCategoryRequest request) {
+        BlogCategory category = new BlogCategory();
+        applyRequest(category, request);
+        ensureUniqueSlug(category.getSlug(), null);
+        BlogCategory saved = blogCategoryRepository.save(category);
+        activityRecorder.record("Blog", "CREATE_CATEGORY", "Created category " + saved.getName(), "SUCCESS", buildContext(saved));
+        return blogCategoryMapper.toDto(saved);
+    }
+
+    @Transactional
+    public BlogCategoryDto update(Long id, BlogCategoryRequest request) {
+        BlogCategory category = blogCategoryRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Category not found"));
+        String previousSlug = category.getSlug();
+        applyRequest(category, request);
+        ensureUniqueSlug(category.getSlug(), category.getId());
+        BlogCategory saved = blogCategoryRepository.save(category);
+        activityRecorder.record("Blog", "UPDATE_CATEGORY", "Updated category " + saved.getName(), "SUCCESS", buildContext(saved));
+        if (!previousSlug.equalsIgnoreCase(saved.getSlug())) {
+            activityRecorder.record("Blog", "CATEGORY_SLUG_CHANGED", "Category slug changed", "SUCCESS", Map.of(
+                    "previousSlug", previousSlug,
+                    "newSlug", saved.getSlug(),
+                    "categoryId", saved.getId()
+            ));
+        }
+        return blogCategoryMapper.toDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        BlogCategory category = blogCategoryRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Category not found"));
+        long postCount = blogPostRepository.countByCategoryId(id);
+        if (postCount > 0) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Cannot delete category with existing posts");
+        }
+        blogCategoryRepository.delete(category);
+        activityRecorder.record("Blog", "DELETE_CATEGORY", "Deleted category " + category.getName(), "SUCCESS", buildContext(category));
+    }
+
+    private void applyRequest(BlogCategory category, BlogCategoryRequest request) {
+        category.setName(request.getName());
+        category.setSlug(normalizeSlug(request.getSlug(), request.getName()));
+        category.setDescription(request.getDescription());
+    }
+
+    private void ensureUniqueSlug(String slug, Long categoryId) {
+        if (slug == null || slug.isBlank()) {
+            return;
+        }
+        boolean exists = categoryId == null
+                ? blogCategoryRepository.existsBySlugIgnoreCase(slug)
+                : blogCategoryRepository.existsBySlugIgnoreCaseAndIdNot(slug, categoryId);
+        if (exists) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Category slug already exists");
+        }
+    }
+
+    private String normalizeSlug(String slug, String fallback) {
+        String value = Optional.ofNullable(slug).filter(s -> !s.isBlank()).orElse(fallback);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String sanitized = value.trim().toLowerCase();
+        sanitized = sanitized.replaceAll("[^a-z0-9\\s-_]", "");
+        sanitized = sanitized.replaceAll("[\\s-_]+", "-");
+        if (sanitized.isBlank()) {
+            sanitized = "category-" + Long.toHexString(System.nanoTime());
+        }
+        return sanitized.length() > 160 ? sanitized.substring(0, 160) : sanitized;
+    }
+
+    private Map<String, Object> buildContext(BlogCategory category) {
+        Map<String, Object> context = new HashMap<>();
+        context.put("categoryId", category.getId());
+        context.put("categorySlug", category.getSlug());
+        context.put("categoryName", category.getName());
+        return context;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/service/BlogMediaStorageService.java
+++ b/backend/src/main/java/com/example/rbac/blog/service/BlogMediaStorageService.java
@@ -1,0 +1,85 @@
+package com.example.rbac.blog.service;
+
+import com.example.rbac.common.exception.ApiException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+public class BlogMediaStorageService {
+
+    private final Path storageRoot;
+
+    public BlogMediaStorageService(@Value("${app.blog.storage-path:storage/blog}") String storagePath) {
+        this.storageRoot = Paths.get(storagePath).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.storageRoot);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to initialize blog storage directory", ex);
+        }
+    }
+
+    public String store(MultipartFile file) {
+        try {
+            String extension = extractExtension(file.getOriginalFilename());
+            String filename = UUID.randomUUID() + (extension == null ? "" : "." + extension);
+            Path destination = storageRoot.resolve(filename);
+            Files.copy(file.getInputStream(), destination, StandardCopyOption.REPLACE_EXISTING);
+            return filename;
+        } catch (IOException ex) {
+            throw new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to store media file");
+        }
+    }
+
+    public Resource load(String key) {
+        try {
+            Path path = storageRoot.resolve(key).normalize();
+            if (!path.startsWith(storageRoot)) {
+                throw new ApiException(HttpStatus.BAD_REQUEST, "Invalid media path");
+            }
+            Resource resource = new UrlResource(path.toUri());
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            }
+            throw new ApiException(HttpStatus.NOT_FOUND, "Media not found");
+        } catch (MalformedURLException ex) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Invalid media path");
+        }
+    }
+
+    public void delete(String key) {
+        if (key == null || key.isBlank()) {
+            return;
+        }
+        try {
+            Path path = storageRoot.resolve(key).normalize();
+            if (path.startsWith(storageRoot)) {
+                Files.deleteIfExists(path);
+            }
+        } catch (IOException ex) {
+            // ignore deletion errors
+        }
+    }
+
+    private String extractExtension(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return null;
+        }
+        int index = filename.lastIndexOf('.');
+        if (index <= 0 || index == filename.length() - 1) {
+            return null;
+        }
+        return filename.substring(index + 1).toLowerCase();
+    }
+}

--- a/backend/src/main/java/com/example/rbac/blog/service/BlogPostService.java
+++ b/backend/src/main/java/com/example/rbac/blog/service/BlogPostService.java
@@ -1,0 +1,236 @@
+package com.example.rbac.blog.service;
+
+import com.example.rbac.activity.service.ActivityRecorder;
+import com.example.rbac.blog.dto.BlogPostDto;
+import com.example.rbac.blog.dto.BlogPostRequest;
+import com.example.rbac.blog.dto.PublicBlogPostDto;
+import com.example.rbac.blog.mapper.BlogPostMapper;
+import com.example.rbac.blog.model.BlogCategory;
+import com.example.rbac.blog.model.BlogPost;
+import com.example.rbac.blog.repository.BlogCategoryRepository;
+import com.example.rbac.blog.repository.BlogPostRepository;
+import com.example.rbac.common.exception.ApiException;
+import com.example.rbac.common.pagination.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+public class BlogPostService {
+
+    private final BlogPostRepository blogPostRepository;
+    private final BlogCategoryRepository blogCategoryRepository;
+    private final BlogPostMapper blogPostMapper;
+    private final ActivityRecorder activityRecorder;
+    private final BlogMediaStorageService blogMediaStorageService;
+
+    public BlogPostService(BlogPostRepository blogPostRepository,
+                           BlogCategoryRepository blogCategoryRepository,
+                           BlogPostMapper blogPostMapper,
+                           ActivityRecorder activityRecorder,
+                           BlogMediaStorageService blogMediaStorageService) {
+        this.blogPostRepository = blogPostRepository;
+        this.blogCategoryRepository = blogCategoryRepository;
+        this.blogPostMapper = blogPostMapper;
+        this.activityRecorder = activityRecorder;
+        this.blogMediaStorageService = blogMediaStorageService;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<BlogPostDto> list(int page,
+                                          int size,
+                                          String sort,
+                                          String direction,
+                                          Long categoryId,
+                                          Boolean published,
+                                          String search) {
+        Sort.Direction sortDirection = "asc".equalsIgnoreCase(direction) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        String sortProperty = switch (Optional.ofNullable(sort).orElse("createdAt")) {
+            case "title" -> "title";
+            case "publishedAt" -> "publishedAt";
+            default -> "createdAt";
+        };
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.max(size, 1), Sort.by(sortDirection, sortProperty));
+        Specification<BlogPost> specification = Specification.where(null);
+        if (categoryId != null) {
+            specification = specification.and((root, query, builder) -> builder.equal(root.get("category").get("id"), categoryId));
+        }
+        if (published != null) {
+            specification = specification.and((root, query, builder) -> builder.equal(root.get("published"), published));
+        }
+        if (search != null && !search.isBlank()) {
+            String like = "%" + search.trim().toLowerCase() + "%";
+            specification = specification.and((root, query, builder) -> builder.or(
+                    builder.like(builder.lower(root.get("title")), like),
+                    builder.like(builder.lower(root.get("slug")), like),
+                    builder.like(builder.lower(root.get("metaTitle")), like)
+            ));
+        }
+        Page<BlogPost> result = blogPostRepository.findAll(specification, pageable);
+        return PageResponse.from(result.map(blogPostMapper::toDto));
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<PublicBlogPostDto> listPublished(int page, int size, String categorySlug, String search) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), Math.max(size, 1), Sort.by(Sort.Direction.DESC, "publishedAt"));
+        Specification<BlogPost> specification = Specification.where((root, query, builder) -> builder.isTrue(root.get("published")));
+        specification = specification.and((root, query, builder) -> builder.isNotNull(root.get("publishedAt")));
+        if (categorySlug != null && !categorySlug.isBlank()) {
+            specification = specification.and((root, query, builder) -> builder.equal(builder.lower(root.get("category").get("slug")), categorySlug.toLowerCase()));
+        }
+        if (search != null && !search.isBlank()) {
+            String like = "%" + search.trim().toLowerCase() + "%";
+            specification = specification.and((root, query, builder) -> builder.or(
+                    builder.like(builder.lower(root.get("title")), like),
+                    builder.like(builder.lower(root.get("slug")), like),
+                    builder.like(builder.lower(root.get("metaTitle")), like)
+            ));
+        }
+        Page<BlogPost> result = blogPostRepository.findAll(specification, pageable);
+        return PageResponse.from(result.map(blogPostMapper::toPublicDto));
+    }
+
+    @Transactional(readOnly = true)
+    public BlogPostDto get(Long id) {
+        BlogPost post = blogPostRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Post not found"));
+        return blogPostMapper.toDto(post);
+    }
+
+    @Transactional(readOnly = true)
+    public PublicBlogPostDto getPublishedPost(String slug) {
+        if (slug == null || slug.isBlank()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Post slug is required");
+        }
+        BlogPost post = blogPostRepository.findBySlugIgnoreCase(slug.trim())
+                .filter(BlogPost::isPublished)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Post not found"));
+        return blogPostMapper.toPublicDto(post);
+    }
+
+    @Transactional
+    public BlogPostDto create(BlogPostRequest request) {
+        BlogCategory category = blogCategoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new ApiException(HttpStatus.BAD_REQUEST, "Category not found"));
+        BlogPost post = new BlogPost();
+        post.setCategory(category);
+        applyRequest(post, request);
+        ensureUniqueSlug(post.getSlug(), null);
+        BlogPost saved = blogPostRepository.save(post);
+        activityRecorder.record("Blog", "CREATE_POST", "Created post " + saved.getTitle(), "SUCCESS", buildContext(saved));
+        return blogPostMapper.toDto(saved);
+    }
+
+    @Transactional
+    public BlogPostDto update(Long id, BlogPostRequest request) {
+        BlogPost post = blogPostRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Post not found"));
+        BlogCategory category = blogCategoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new ApiException(HttpStatus.BAD_REQUEST, "Category not found"));
+        String previousBanner = post.getBannerImage();
+        String previousMetaImage = post.getMetaImage();
+        String previousSlug = post.getSlug();
+        post.setCategory(category);
+        applyRequest(post, request);
+        ensureUniqueSlug(post.getSlug(), post.getId());
+        BlogPost saved = blogPostRepository.save(post);
+        cleanupMedia(previousBanner, saved.getBannerImage());
+        cleanupMedia(previousMetaImage, saved.getMetaImage());
+        activityRecorder.record("Blog", "UPDATE_POST", "Updated post " + saved.getTitle(), "SUCCESS", buildContext(saved));
+        if (!previousSlug.equalsIgnoreCase(saved.getSlug())) {
+            activityRecorder.record("Blog", "POST_SLUG_CHANGED", "Post slug changed", "SUCCESS", Map.of(
+                    "previousSlug", previousSlug,
+                    "newSlug", saved.getSlug(),
+                    "postId", saved.getId()
+            ));
+        }
+        return blogPostMapper.toDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        BlogPost post = blogPostRepository.findById(id)
+                .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "Post not found"));
+        blogPostRepository.delete(post);
+        activityRecorder.record("Blog", "DELETE_POST", "Deleted post " + post.getTitle(), "SUCCESS", buildContext(post));
+        cleanupMedia(post.getBannerImage(), null);
+        cleanupMedia(post.getMetaImage(), null);
+    }
+
+    private void cleanupMedia(String previous, String current) {
+        if (previous == null || previous.isBlank()) {
+            return;
+        }
+        if (current != null && current.equals(previous)) {
+            return;
+        }
+        blogMediaStorageService.delete(previous);
+    }
+
+    private void applyRequest(BlogPost post, BlogPostRequest request) {
+        post.setTitle(request.getTitle());
+        post.setSlug(normalizeSlug(request.getSlug(), request.getTitle()));
+        post.setDescription(request.getDescription());
+        post.setBannerImage(trimToNull(request.getBannerImage()));
+        post.setMetaTitle(trimToNull(request.getMetaTitle()));
+        post.setMetaDescription(trimToNull(request.getMetaDescription()));
+        post.setMetaKeywords(trimToNull(request.getMetaKeywords()));
+        post.setMetaImage(trimToNull(request.getMetaImage()));
+        post.setPublished(request.isPublished());
+        if (!request.isPublished()) {
+            post.setPublishedAt(null);
+        }
+    }
+
+    private void ensureUniqueSlug(String slug, Long postId) {
+        if (slug == null || slug.isBlank()) {
+            return;
+        }
+        boolean exists = postId == null
+                ? blogPostRepository.existsBySlugIgnoreCase(slug)
+                : blogPostRepository.existsBySlugIgnoreCaseAndIdNot(slug, postId);
+        if (exists) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "Post slug already exists");
+        }
+    }
+
+    private String normalizeSlug(String slug, String fallback) {
+        String value = Optional.ofNullable(slug).filter(s -> !s.isBlank()).orElse(fallback);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String sanitized = value.trim().toLowerCase();
+        sanitized = sanitized.replaceAll("[^a-z0-9\\s-_]", "");
+        sanitized = sanitized.replaceAll("[\\s-_]+", "-");
+        if (sanitized.isBlank()) {
+            sanitized = "post-" + Long.toHexString(System.nanoTime());
+        }
+        return sanitized.length() > 210 ? sanitized.substring(0, 210) : sanitized;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private Map<String, Object> buildContext(BlogPost post) {
+        Map<String, Object> context = new HashMap<>();
+        context.put("postId", post.getId());
+        context.put("postSlug", post.getSlug());
+        context.put("categoryId", post.getCategory().getId());
+        context.put("published", post.isPublished());
+        return context;
+    }
+}

--- a/backend/src/main/java/com/example/rbac/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/rbac/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -29,6 +30,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/**", "/api/v1/settings/theme", "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/blog/public/**", "/api/v1/blog/media/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
+++ b/backend/src/main/java/com/example/rbac/gallery/controller/GalleryController.java
@@ -36,11 +36,12 @@ public class GalleryController {
                                                   @RequestParam(name = "sort", required = false) String sort,
                                                   @RequestParam(name = "direction", required = false) String direction,
                                                   @RequestParam(name = "folderId", required = false) Long folderId,
+                                                  @RequestParam(name = "ownerId", required = false) Long ownerId,
                                                   @RequestParam(name = "uploaderId", required = false) Long uploaderId,
                                                   @RequestParam(name = "uploader", required = false) String uploaderEmail,
                                                   @RequestParam(name = "search", required = false) String search,
                                                   @AuthenticationPrincipal UserPrincipal principal) {
-        return galleryService.list(page, size, sort, direction, folderId, uploaderId, uploaderEmail, search, principal);
+        return galleryService.list(page, size, sort, direction, folderId, ownerId, uploaderId, uploaderEmail, search, principal);
     }
 
     @PostMapping("/files")
@@ -103,6 +104,13 @@ public class GalleryController {
     public GalleryFolderDto renameFolder(@PathVariable("id") Long id,
                                          @Valid @RequestBody GalleryFolderRenameRequest request) {
         return galleryService.renameFolder(id, request);
+    }
+
+    @DeleteMapping("/folders/{id}")
+    @PreAuthorize("hasAnyAuthority('GALLERY_EDIT_ALL','GALLERY_CREATE')")
+    public void deleteFolder(@PathVariable("id") Long id,
+                             @AuthenticationPrincipal UserPrincipal principal) {
+        galleryService.deleteFolder(id, principal);
     }
 
     private String encodeFilename(String filename) {

--- a/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFileRepository.java
+++ b/backend/src/main/java/com/example/rbac/gallery/repository/GalleryFileRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface GalleryFileRepository extends JpaRepository<GalleryFile, Long>, JpaSpecificationExecutor<GalleryFile> {
+
+    long countByFolderId(Long folderId);
 }

--- a/backend/src/main/java/com/example/rbac/gallery/service/GallerySettingsService.java
+++ b/backend/src/main/java/com/example/rbac/gallery/service/GallerySettingsService.java
@@ -5,6 +5,7 @@ import com.example.rbac.settings.repository.SettingRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -25,14 +26,15 @@ public class GallerySettingsService {
         Optional<Setting> setting = settingRepository.findByCode(ALLOWED_EXTENSIONS_CODE);
         String configured = setting.map(Setting::getValue).orElse(null);
         if (configured == null || configured.isBlank()) {
-            return List.of("png", "jpg", "jpeg", "pdf", "docx", "xlsx", "mp4");
+            return List.of("png", "jpg", "jpeg", "gif", "pdf", "docx", "xlsx", "mp4", "zip");
         }
-        return Arrays.stream(configured.split(","))
+        LinkedHashSet<String> normalized = Arrays.stream(configured.split(","))
                 .map(String::trim)
                 .filter(value -> !value.isBlank())
-                .map(value -> normalizeExtension(value))
-                .distinct()
-                .collect(Collectors.toList());
+                .map(this::normalizeExtension)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        normalized.add("zip");
+        return normalized.stream().collect(Collectors.toList());
     }
 
     private String normalizeExtension(String value) {

--- a/backend/src/main/java/com/example/rbac/setup/service/SetupService.java
+++ b/backend/src/main/java/com/example/rbac/setup/service/SetupService.java
@@ -248,13 +248,13 @@ public class SetupService {
     }
 
     private static final List<MenuDefinition> DEFAULT_MENU = List.of(
-            MenuDefinition.item("dashboard", "Dashboard", "🏠", "/dashboard", List.of()),
+            MenuDefinition.item("dashboard", "Dashboard", "🏠", "/admin/dashboard", List.of()),
             MenuDefinition.group("sales", "Sales", "⚡", List.of(
                     MenuDefinition.item(
                             "invoices",
                             "Invoices",
                             "📄",
-                            "/invoices",
+                            "/admin/invoices",
                             List.of("INVOICE_VIEW", "INVOICE_VIEW_GLOBAL", "INVOICE_VIEW_OWN", "INVOICE_CREATE", "INVOICE_UPDATE", "INVOICE_DELETE")
                     )
             )),
@@ -263,29 +263,45 @@ public class SetupService {
                             "users",
                             "Users",
                             "👥",
-                            "/users",
+                            "/admin/users",
                             List.of("USER_VIEW", "USER_VIEW_GLOBAL", "USER_VIEW_OWN", "USER_CREATE", "USER_UPDATE", "USER_DELETE")
                     ),
                     MenuDefinition.item(
                             "roles",
                             "Roles",
                             "🧩",
-                            "/roles",
+                            "/admin/roles",
                             List.of("ROLE_VIEW", "ROLE_VIEW_GLOBAL", "ROLE_VIEW_OWN")
                     ),
                     MenuDefinition.item(
                             "permissions",
                             "Permissions",
                             "🛡️",
-                            "/permissions",
+                            "/admin/permissions",
                             List.of("PERMISSION_VIEW")
                     )
             )),
-            MenuDefinition.item("gallery", "Gallery", "🖼️", "/gallery", List.of("GALLERY_VIEW_ALL", "GALLERY_VIEW_OWN", "GALLERY_CREATE")),
-            MenuDefinition.item("activity", "Activity", "📝", "/activity", List.of("ACTIVITY_VIEW")),
-            MenuDefinition.item("settings", "Settings", "⚙️", "/settings", List.of("SETTINGS_VIEW")),
-            MenuDefinition.item("setup", "Setup", "🧭", "/setup", List.of("SETUP_MANAGE")),
-            MenuDefinition.item("profile", "Profile", "👤", "/profile", List.of())
+            MenuDefinition.group("content", "Content", "📰", List.of(
+                    MenuDefinition.item(
+                            "blogCategories",
+                            "Categories",
+                            "🗂️",
+                            "/admin/blog/categories",
+                            List.of("BLOG_CATEGORY_VIEW")
+                    ),
+                    MenuDefinition.item(
+                            "blogPosts",
+                            "All Posts",
+                            "✍️",
+                            "/admin/blog/posts",
+                            List.of("BLOG_POST_VIEW")
+                    )
+            )),
+            MenuDefinition.item("gallery", "Gallery", "🖼️", "/admin/gallery", List.of("GALLERY_VIEW_ALL", "GALLERY_VIEW_OWN", "GALLERY_CREATE")),
+            MenuDefinition.item("activity", "Activity", "📝", "/admin/activity", List.of("ACTIVITY_VIEW")),
+            MenuDefinition.item("settings", "Settings", "⚙️", "/admin/settings", List.of("SETTINGS_VIEW")),
+            MenuDefinition.item("setup", "Setup", "🧭", "/admin/setup", List.of("SETUP_MANAGE")),
+            MenuDefinition.item("profile", "Profile", "👤", "/admin/profile", List.of())
     );
 
     private record MenuDefinition(String key, String label, String icon, String path,

--- a/backend/src/main/resources/db/migration/V16__blog_module.sql
+++ b/backend/src/main/resources/db/migration/V16__blog_module.sql
@@ -1,0 +1,78 @@
+CREATE TABLE blog_categories (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(150) NOT NULL,
+    slug VARCHAR(160) NOT NULL UNIQUE,
+    description TEXT,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+);
+
+CREATE TABLE blog_posts (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    category_id BIGINT NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    slug VARCHAR(210) NOT NULL UNIQUE,
+    description LONGTEXT NOT NULL,
+    banner_image VARCHAR(255),
+    meta_title VARCHAR(200),
+    meta_description TEXT,
+    meta_keywords TEXT,
+    meta_image VARCHAR(255),
+    published TINYINT(1) NOT NULL DEFAULT 0,
+    published_at DATETIME(6),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    CONSTRAINT fk_blog_posts_category FOREIGN KEY (category_id) REFERENCES blog_categories(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_blog_posts_category ON blog_posts(category_id);
+CREATE INDEX idx_blog_posts_published ON blog_posts(published);
+CREATE INDEX idx_blog_posts_published_at ON blog_posts(published_at);
+
+INSERT INTO permissions (code, name) VALUES
+    ('BLOG_CATEGORY_VIEW', 'Blog Categories: View'),
+    ('BLOG_CATEGORY_CREATE', 'Blog Categories: Create'),
+    ('BLOG_CATEGORY_UPDATE', 'Blog Categories: Update'),
+    ('BLOG_CATEGORY_DELETE', 'Blog Categories: Delete'),
+    ('BLOG_POST_VIEW', 'Blog Posts: View'),
+    ('BLOG_POST_CREATE', 'Blog Posts: Create'),
+    ('BLOG_POST_UPDATE', 'Blog Posts: Update'),
+    ('BLOG_POST_DELETE', 'Blog Posts: Delete');
+
+-- Assign new permissions to super admin
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code IN (
+    'BLOG_CATEGORY_VIEW',
+    'BLOG_CATEGORY_CREATE',
+    'BLOG_CATEGORY_UPDATE',
+    'BLOG_CATEGORY_DELETE',
+    'BLOG_POST_VIEW',
+    'BLOG_POST_CREATE',
+    'BLOG_POST_UPDATE',
+    'BLOG_POST_DELETE'
+)
+WHERE r.code = 'SUPER_ADMIN'
+  AND NOT EXISTS (
+    SELECT 1 FROM role_permissions rp WHERE rp.role_id = r.id AND rp.permission_id = p.id
+);
+
+-- Provide blog management access to administrators by default
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON p.code IN (
+    'BLOG_CATEGORY_VIEW',
+    'BLOG_CATEGORY_CREATE',
+    'BLOG_CATEGORY_UPDATE',
+    'BLOG_CATEGORY_DELETE',
+    'BLOG_POST_VIEW',
+    'BLOG_POST_CREATE',
+    'BLOG_POST_UPDATE',
+    'BLOG_POST_DELETE'
+)
+WHERE r.code = 'ADMIN'
+  AND NOT EXISTS (
+    SELECT 1 FROM role_permissions rp WHERE rp.role_id = r.id AND rp.permission_id = p.id
+);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,10 @@ import ActivityPage from './pages/ActivityPage';
 import ActivityDetailPage from './pages/ActivityDetailPage';
 import SetupPage from './pages/SetupPage';
 import GalleryPage from './pages/GalleryPage';
+import BlogCategoriesPage from './pages/BlogCategoriesPage';
+import BlogPostsPage from './pages/BlogPostsPage';
+import PublicBlogListPage from './pages/PublicBlogListPage';
+import PublicBlogPostPage from './pages/PublicBlogPostPage';
 
 const App = () => {
   const dispatch = useAppDispatch();
@@ -112,10 +116,12 @@ const App = () => {
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup" element={<SignupPage />} />
+      <Route path="/blog" element={<PublicBlogListPage />} />
+      <Route path="/blog/:slug" element={<PublicBlogPostPage />} />
       <Route element={<ProtectedRoute />}>
-        <Route element={<Layout />}>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/admin" element={<Layout />}>
+          <Route index element={<Navigate to="dashboard" replace />} />
+          <Route path="dashboard" element={<DashboardPage />} />
           <Route
             element={
               <PermissionRoute
@@ -130,13 +136,13 @@ const App = () => {
               />
             }
           >
-            <Route path="/users" element={<UsersPage />} />
+            <Route path="users" element={<UsersPage />} />
           </Route>
           <Route element={<PermissionRoute required={['ROLE_VIEW', 'ROLE_VIEW_GLOBAL', 'ROLE_VIEW_OWN']} />}>
-            <Route path="/roles" element={<RolesPage />} />
+            <Route path="roles" element={<RolesPage />} />
           </Route>
           <Route element={<PermissionRoute required={['PERMISSION_VIEW']} />}>
-            <Route path="/permissions" element={<PermissionsPage />} />
+            <Route path="permissions" element={<PermissionsPage />} />
           </Route>
           <Route
             element={
@@ -152,30 +158,37 @@ const App = () => {
               />
             }
           >
-            <Route path="/invoices" element={<InvoicesPage />} />
+            <Route path="invoices" element={<InvoicesPage />} />
+          </Route>
+          <Route element={<PermissionRoute required={['BLOG_CATEGORY_VIEW']} />}>
+            <Route path="blog/categories" element={<BlogCategoriesPage />} />
+          </Route>
+          <Route element={<PermissionRoute required={['BLOG_POST_VIEW']} />}>
+            <Route path="blog/posts" element={<BlogPostsPage />} />
           </Route>
           <Route element={<PermissionRoute required={['ACTIVITY_VIEW']} />}>
-            <Route path="/activity" element={<ActivityPage />} />
-            <Route path="/activity/:id" element={<ActivityDetailPage />} />
+            <Route path="activity" element={<ActivityPage />} />
+            <Route path="activity/:id" element={<ActivityDetailPage />} />
           </Route>
           <Route element={<PermissionRoute required={['SETTINGS_VIEW']} />}>
-            <Route path="/settings" element={<SettingsPage />} />
+            <Route path="settings" element={<SettingsPage />} />
           </Route>
           <Route
             element={
               <PermissionRoute required={['GALLERY_VIEW_ALL', 'GALLERY_VIEW_OWN', 'GALLERY_CREATE']} />
             }
           >
-            <Route path="/gallery" element={<GalleryPage />} />
+            <Route path="gallery" element={<GalleryPage />} />
           </Route>
           <Route element={<PermissionRoute required={['SETUP_MANAGE']} />}>
-            <Route path="/setup" element={<SetupPage />} />
+            <Route path="setup" element={<SetupPage />} />
           </Route>
-          <Route path="/profile" element={<ProfilePage />} />
-          <Route path="/403" element={<ForbiddenPage />} />
+          <Route path="profile" element={<ProfilePage />} />
+          <Route path="403" element={<ForbiddenPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Route>
+      <Route path="/" element={<Navigate to="/admin" replace />} />
       <Route path="*" element={<Navigate to="/login" replace />} />
     </Routes>
   );

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -178,7 +178,7 @@ const Layout = () => {
 
   const handleProfileNavigate = () => {
     setProfileMenuOpen(false);
-    navigate('/profile');
+    navigate('/admin/profile');
   };
 
   return (
@@ -327,7 +327,7 @@ const Layout = () => {
               <NavLink
                 key={item.key}
                 to={item.to ?? '#'}
-                end={item.to === '/dashboard'}
+                end={item.to === '/admin/dashboard'}
                 title={sidebarCollapsed ? item.label : undefined}
                 className={({ isActive }) =>
                   `group flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors ${

--- a/frontend/src/constants/navigation.ts
+++ b/frontend/src/constants/navigation.ts
@@ -5,7 +5,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
     key: 'dashboard',
     label: 'Dashboard',
     icon: '🏠',
-    path: '/dashboard',
+    path: '/admin/dashboard',
     group: false,
     permissions: [],
     children: []
@@ -22,7 +22,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
         key: 'invoices',
         label: 'Invoices',
         icon: '📄',
-        path: '/invoices',
+        path: '/admin/invoices',
         group: false,
         permissions: [
           'INVOICE_VIEW',
@@ -48,7 +48,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
         key: 'users',
         label: 'Users',
         icon: '👥',
-        path: '/users',
+        path: '/admin/users',
         group: false,
         permissions: [
           'USER_VIEW',
@@ -64,7 +64,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
         key: 'roles',
         label: 'Roles',
         icon: '🧩',
-        path: '/roles',
+        path: '/admin/roles',
         group: false,
         permissions: ['ROLE_VIEW', 'ROLE_VIEW_GLOBAL', 'ROLE_VIEW_OWN'],
         children: []
@@ -73,9 +73,37 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
         key: 'permissions',
         label: 'Permissions',
         icon: '🛡️',
-        path: '/permissions',
+        path: '/admin/permissions',
         group: false,
         permissions: ['PERMISSION_VIEW'],
+        children: []
+      }
+    ]
+  },
+  {
+    key: 'content',
+    label: 'Content',
+    icon: '📰',
+    path: undefined,
+    group: true,
+    permissions: [],
+    children: [
+      {
+        key: 'blogCategories',
+        label: 'Categories',
+        icon: '🗂️',
+        path: '/admin/blog/categories',
+        group: false,
+        permissions: ['BLOG_CATEGORY_VIEW'],
+        children: []
+      },
+      {
+        key: 'blogPosts',
+        label: 'All Posts',
+        icon: '✍️',
+        path: '/admin/blog/posts',
+        group: false,
+        permissions: ['BLOG_POST_VIEW'],
         children: []
       }
     ]
@@ -84,7 +112,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
     key: 'activity',
     label: 'Activity',
     icon: '📝',
-    path: '/activity',
+    path: '/admin/activity',
     group: false,
     permissions: ['ACTIVITY_VIEW'],
     children: []
@@ -93,7 +121,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
     key: 'gallery',
     label: 'Gallery',
     icon: '🖼️',
-    path: '/gallery',
+    path: '/admin/gallery',
     group: false,
     permissions: ['GALLERY_VIEW_ALL', 'GALLERY_VIEW_OWN', 'GALLERY_CREATE'],
     children: []
@@ -102,7 +130,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
     key: 'settings',
     label: 'Settings',
     icon: '⚙️',
-    path: '/settings',
+    path: '/admin/settings',
     group: false,
     permissions: ['SETTINGS_VIEW'],
     children: []
@@ -111,7 +139,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
     key: 'setup',
     label: 'Setup',
     icon: '🧭',
-    path: '/setup',
+    path: '/admin/setup',
     group: false,
     permissions: ['SETUP_MANAGE'],
     children: []
@@ -120,7 +148,7 @@ export const DEFAULT_NAVIGATION_MENU: NavigationNode[] = [
     key: 'profile',
     label: 'Profile',
     icon: '👤',
-    path: '/profile',
+    path: '/admin/profile',
     group: false,
     permissions: [],
     children: []

--- a/frontend/src/pages/BlogCategoriesPage.tsx
+++ b/frontend/src/pages/BlogCategoriesPage.tsx
@@ -1,0 +1,375 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '../services/http';
+import type { BlogCategory, BlogCategoryPage } from '../types/blog';
+import { useAppSelector } from '../app/hooks';
+import { hasAnyPermission } from '../utils/permissions';
+import type { PermissionKey } from '../types/auth';
+import { useToast } from '../components/ToastProvider';
+import { extractErrorMessage } from '../utils/errors';
+
+interface CategoryFormState {
+  name: string;
+  slug: string;
+  description: string;
+}
+
+type FormMode = 'create' | 'edit';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+const BlogCategoriesPage = () => {
+  const queryClient = useQueryClient();
+  const { notify } = useToast();
+  const permissions = useAppSelector((state) => state.auth.permissions);
+
+  const [page, setPage] = useState(0);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [formMode, setFormMode] = useState<FormMode>('create');
+  const [form, setForm] = useState<CategoryFormState>({ name: '', slug: '', description: '' });
+  const [formError, setFormError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const canCreate = useMemo(
+    () => hasAnyPermission(permissions as PermissionKey[], ['BLOG_CATEGORY_CREATE']),
+    [permissions]
+  );
+  const canUpdate = useMemo(
+    () => hasAnyPermission(permissions as PermissionKey[], ['BLOG_CATEGORY_UPDATE']),
+    [permissions]
+  );
+  const canDelete = useMemo(
+    () => hasAnyPermission(permissions as PermissionKey[], ['BLOG_CATEGORY_DELETE']),
+    [permissions]
+  );
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearch(searchDraft.trim());
+      setPage(0);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  const categoriesQuery = useQuery<BlogCategoryPage>({
+    queryKey: ['blog', 'categories', { page, search }],
+    queryFn: async () => {
+      const { data } = await api.get<BlogCategoryPage>('/blog/categories', {
+        params: { page, size: DEFAULT_PAGE_SIZE, search }
+      });
+      return data;
+    }
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: CategoryFormState) => {
+      const { data } = await api.post<BlogCategory>('/blog/categories', payload);
+      return data;
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Category created successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['blog', 'categories'] });
+    },
+    onError: (error: unknown) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Failed to create category.') });
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, payload }: { id: number; payload: CategoryFormState }) => {
+      const { data } = await api.put<BlogCategory>(`/blog/categories/${id}`, payload);
+      return data;
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Category updated successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['blog', 'categories'] });
+    },
+    onError: (error: unknown) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Failed to update category.') });
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await api.delete(`/blog/categories/${id}`);
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Category deleted successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['blog', 'categories'] });
+    },
+    onError: (error: unknown) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Failed to delete category.') });
+    }
+  });
+
+  const openCreateModal = () => {
+    setForm({ name: '', slug: '', description: '' });
+    setFormError(null);
+    setEditingId(null);
+    setFormMode('create');
+    setIsModalOpen(true);
+  };
+
+  const openEditModal = (category: BlogCategory) => {
+    setForm({
+      name: category.name,
+      slug: category.slug,
+      description: category.description ?? ''
+    });
+    setFormError(null);
+    setEditingId(category.id);
+    setFormMode('edit');
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setFormError(null);
+  };
+
+  const handleSubmit = async () => {
+    if (!form.name.trim()) {
+      setFormError('Name is required.');
+      return;
+    }
+    const payload: CategoryFormState = {
+      name: form.name.trim(),
+      slug: form.slug.trim(),
+      description: form.description.trim()
+    };
+    try {
+      if (formMode === 'create') {
+        await createMutation.mutateAsync(payload);
+      } else if (editingId != null) {
+        await updateMutation.mutateAsync({ id: editingId, payload });
+      }
+      closeModal();
+    } catch (error) {
+      setFormError(extractErrorMessage(error, 'Failed to save category.'));
+    }
+  };
+
+  const handleDelete = async (category: BlogCategory) => {
+    if (!canDelete) {
+      return;
+    }
+    const confirmed = window.confirm(`Delete category "${category.name}"? This cannot be undone.`);
+    if (!confirmed) {
+      return;
+    }
+    await deleteMutation.mutateAsync(category.id);
+  };
+
+  const totalPages = categoriesQuery.data?.totalPages ?? 0;
+  const totalElements = categoriesQuery.data?.totalElements ?? 0;
+  const pageCount = categoriesQuery.data?.content.length ?? 0;
+  const showingFrom = totalElements === 0 ? 0 : page * DEFAULT_PAGE_SIZE + 1;
+  const showingTo = totalElements === 0 ? 0 : page * DEFAULT_PAGE_SIZE + pageCount;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800">Blog Categories</h1>
+          <p className="text-sm text-slate-500">Organize posts into meaningful categories to keep content discoverable.</p>
+        </div>
+        {canCreate && (
+          <button
+            type="button"
+            onClick={openCreateModal}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-600"
+          >
+            New Category
+          </button>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-col gap-4 border-b border-slate-200 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <input
+            type="search"
+            value={searchDraft}
+            onChange={(event) => setSearchDraft(event.target.value)}
+            placeholder="Search categories"
+            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 sm:max-w-xs"
+          />
+          <div className="text-sm text-slate-500">
+            Page {page + 1} of {Math.max(totalPages, 1)}
+          </div>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Name</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Slug</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Description</th>
+                {(canUpdate || canDelete) && <th className="px-4 py-3 text-right font-medium text-slate-600">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {categoriesQuery.isLoading && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-8 text-center text-slate-500">
+                    Loading categories…
+                  </td>
+                </tr>
+              )}
+              {!categoriesQuery.isLoading && categoriesQuery.data?.content.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-10 text-center text-slate-500">
+                    No categories found.
+                  </td>
+                </tr>
+              )}
+              {categoriesQuery.data?.content.map((category) => (
+                <tr key={category.id} className="divide-x divide-slate-100">
+                  <td className="px-4 py-3 text-slate-700">{category.name}</td>
+                  <td className="px-4 py-3 text-slate-500">{category.slug}</td>
+                  <td className="px-4 py-3 text-slate-500">
+                    {category.description ? category.description : <span className="italic text-slate-400">No description</span>}
+                  </td>
+                  {(canUpdate || canDelete) && (
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end gap-2">
+                        {canUpdate && (
+                          <button
+                            type="button"
+                            onClick={() => openEditModal(category)}
+                            className="rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 transition hover:border-primary hover:text-primary"
+                          >
+                            Edit
+                          </button>
+                        )}
+                        {canDelete && (
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(category)}
+                            className="rounded-lg border border-rose-200 px-3 py-1 text-xs font-medium text-rose-500 transition hover:bg-rose-50"
+                          >
+                            Delete
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex items-center justify-between border-t border-slate-200 px-4 py-3 text-sm text-slate-600">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+            disabled={page === 0 || categoriesQuery.isLoading}
+            className="rounded-lg border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-40 hover:border-primary hover:text-primary"
+          >
+            Previous
+          </button>
+          <span>
+            Showing {showingFrom}-{showingTo} of {totalElements}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((prev) => (categoriesQuery.data && prev < categoriesQuery.data.totalPages - 1 ? prev + 1 : prev))}
+            disabled={categoriesQuery.isLoading || (categoriesQuery.data ? page >= categoriesQuery.data.totalPages - 1 : true)}
+            className="rounded-lg border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-40 hover:border-primary hover:text-primary"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+
+      {isModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4">
+          <div className="w-full max-w-lg rounded-2xl bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800">
+                  {formMode === 'create' ? 'Create Category' : 'Edit Category'}
+                </h2>
+                <p className="text-sm text-slate-500">
+                  Define how blog posts are grouped for easier browsing.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+              >
+                <span className="sr-only">Close</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} className="h-5 w-5">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
+                </svg>
+              </button>
+            </div>
+            <div className="space-y-4 px-6 py-4">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="category-name">
+                  Name
+                </label>
+                <input
+                  id="category-name"
+                  type="text"
+                  value={form.name}
+                  onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                  className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  placeholder="Marketing"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="category-slug">
+                  Slug <span className="text-xs font-normal text-slate-400">(optional)</span>
+                </label>
+                <input
+                  id="category-slug"
+                  type="text"
+                  value={form.slug}
+                  onChange={(event) => setForm((prev) => ({ ...prev, slug: event.target.value }))}
+                  className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  placeholder="marketing"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="category-description">
+                  Description <span className="text-xs font-normal text-slate-400">(optional)</span>
+                </label>
+                <textarea
+                  id="category-description"
+                  value={form.description}
+                  onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+                  rows={4}
+                  className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  placeholder="Short summary to help teammates understand where to add their posts."
+                />
+              </div>
+              {formError && <div className="rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-600">{formError}</div>}
+            </div>
+            <div className="flex items-center justify-end gap-3 border-t border-slate-200 px-6 py-4">
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-600"
+                disabled={createMutation.isPending || updateMutation.isPending}
+              >
+                {createMutation.isPending || updateMutation.isPending ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BlogCategoriesPage;

--- a/frontend/src/pages/BlogPostsPage.tsx
+++ b/frontend/src/pages/BlogPostsPage.tsx
@@ -1,0 +1,776 @@
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '../services/http';
+import type { BlogCategory, BlogMediaUploadResponse, BlogPost, BlogPostPage } from '../types/blog';
+import { useToast } from '../components/ToastProvider';
+import { useAppSelector } from '../app/hooks';
+import { hasAnyPermission } from '../utils/permissions';
+import type { PermissionKey } from '../types/auth';
+import { extractErrorMessage } from '../utils/errors';
+
+interface PostFormState {
+  title: string;
+  slug: string;
+  categoryId: number | null;
+  description: string;
+  published: boolean;
+  bannerImage: string | null;
+  metaTitle: string;
+  metaDescription: string;
+  metaKeywords: string;
+  metaImage: string | null;
+}
+
+type FormMode = 'create' | 'edit';
+
+type BlogPostPayload = Omit<PostFormState, 'categoryId'> & { categoryId: number };
+
+const DEFAULT_PAGE_SIZE = 10;
+const EMPTY_FORM: PostFormState = {
+  title: '',
+  slug: '',
+  categoryId: null,
+  description: '',
+  published: false,
+  bannerImage: null,
+  metaTitle: '',
+  metaDescription: '',
+  metaKeywords: '',
+  metaImage: null
+};
+
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim();
+
+const buildMediaUrl = (key?: string | null) => {
+  if (!key) {
+    return null;
+  }
+  const base = api.defaults.baseURL ?? '';
+  return `${base.replace(/\/$/, '')}/blog/media/${key}`;
+};
+
+interface RichTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const RichTextEditor = ({ value, onChange }: RichTextEditorProps) => {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!editorRef.current) {
+      return;
+    }
+    if (editorRef.current.innerHTML !== value) {
+      editorRef.current.innerHTML = value || '<p><br></p>';
+    }
+  }, [value]);
+
+  const exec = useCallback((command: string, argument?: string) => {
+    editorRef.current?.focus();
+    document.execCommand(command, false, argument);
+    onChange(editorRef.current?.innerHTML ?? '');
+  }, [onChange]);
+
+  const handleInput = useCallback(() => {
+    onChange(editorRef.current?.innerHTML ?? '');
+  }, [onChange]);
+
+  const handleInsertLink = () => {
+    const url = window.prompt('Enter link URL');
+    if (url) {
+      exec('createLink', url);
+    }
+  };
+
+  const handleInsertImage = () => {
+    const url = window.prompt('Enter image URL');
+    if (url) {
+      exec('insertImage', url);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-slate-200">
+      <div className="flex flex-wrap gap-2 border-b border-slate-200 bg-slate-50 px-3 py-2">
+        <EditorButton label="Bold" onClick={() => exec('bold')} icon="B" />
+        <EditorButton label="Italic" onClick={() => exec('italic')} icon="I" italic />
+        <EditorButton label="Underline" onClick={() => exec('underline')} icon="U" underline />
+        <EditorButton label="Heading" onClick={() => exec('formatBlock', 'h2')} icon="H2" />
+        <EditorButton label="Paragraph" onClick={() => exec('formatBlock', 'p')} icon="P" />
+        <EditorButton label="Bullet list" onClick={() => exec('insertUnorderedList')} icon="•" />
+        <EditorButton label="Numbered list" onClick={() => exec('insertOrderedList')} icon="1." />
+        <EditorButton label="Quote" onClick={() => exec('formatBlock', 'blockquote')} icon="❝" />
+        <EditorButton label="Link" onClick={handleInsertLink} icon="🔗" />
+        <EditorButton label="Image" onClick={handleInsertImage} icon="🖼️" />
+        <EditorButton label="Clear formatting" onClick={() => exec('removeFormat')} icon="⌫" />
+      </div>
+      <div
+        ref={editorRef}
+        className="min-h-[240px] overflow-auto bg-white px-4 py-3 text-sm leading-relaxed text-slate-700 focus:outline-none"
+        contentEditable
+        suppressContentEditableWarning
+        onInput={handleInput}
+        onBlur={handleInput}
+      />
+    </div>
+  );
+};
+
+interface EditorButtonProps {
+  label: string;
+  icon: string;
+  onClick: () => void;
+  italic?: boolean;
+  underline?: boolean;
+}
+
+const EditorButton = ({ label, icon, onClick, italic, underline }: EditorButtonProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    title={label}
+    className="rounded-lg border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-primary hover:text-primary"
+  >
+    <span className={italic ? 'italic' : underline ? 'underline' : undefined}>{icon}</span>
+  </button>
+);
+
+const BlogPostsPage = () => {
+  const queryClient = useQueryClient();
+  const { notify } = useToast();
+  const permissions = useAppSelector((state) => state.auth.permissions);
+
+  const [page, setPage] = useState(0);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<number | 'all'>('all');
+  const [statusFilter, setStatusFilter] = useState<'all' | 'published' | 'draft'>('all');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [formMode, setFormMode] = useState<FormMode>('create');
+  const [form, setForm] = useState<PostFormState>(EMPTY_FORM);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [mediaPreview, setMediaPreview] = useState<{ bannerImage: string | null; metaImage: string | null }>({
+    bannerImage: null,
+    metaImage: null
+  });
+  const [mediaUploading, setMediaUploading] = useState<{ bannerImage: boolean; metaImage: boolean }>({
+    bannerImage: false,
+    metaImage: false
+  });
+
+  const canCreate = useMemo(
+    () => hasAnyPermission(permissions as PermissionKey[], ['BLOG_POST_CREATE']),
+    [permissions]
+  );
+  const canUpdate = useMemo(
+    () => hasAnyPermission(permissions as PermissionKey[], ['BLOG_POST_UPDATE']),
+    [permissions]
+  );
+  const canDelete = useMemo(
+    () => hasAnyPermission(permissions as PermissionKey[], ['BLOG_POST_DELETE']),
+    [permissions]
+  );
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearch(searchDraft.trim());
+      setPage(0);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [categoryFilter, statusFilter]);
+
+  const categoriesQuery = useQuery<BlogCategory[]>({
+    queryKey: ['blog', 'categories', 'all'],
+    queryFn: async () => {
+      const { data } = await api.get<BlogCategory[]>('/blog/categories/all');
+      return data;
+    }
+  });
+
+  const postsQuery = useQuery<BlogPostPage>({
+    queryKey: ['blog', 'posts', { page, search, categoryFilter, statusFilter }],
+    queryFn: async () => {
+      const params: Record<string, unknown> = { page, size: DEFAULT_PAGE_SIZE, search };
+      if (categoryFilter !== 'all') {
+        params.categoryId = categoryFilter;
+      }
+      if (statusFilter === 'published') {
+        params.published = true;
+      } else if (statusFilter === 'draft') {
+        params.published = false;
+      }
+      const { data } = await api.get<BlogPostPage>('/blog/posts', { params });
+      return data;
+    }
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (payload: BlogPostPayload) => {
+      const { data } = await api.post<BlogPost>('/blog/posts', payload);
+      return data;
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Post created successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['blog', 'posts'] });
+    },
+    onError: (error: unknown) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Failed to create post.') });
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, payload }: { id: number; payload: BlogPostPayload }) => {
+      const { data } = await api.put<BlogPost>(`/blog/posts/${id}`, payload);
+      return data;
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Post updated successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['blog', 'posts'] });
+    },
+    onError: (error: unknown) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Failed to update post.') });
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await api.delete(`/blog/posts/${id}`);
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Post deleted successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['blog', 'posts'] });
+    },
+    onError: (error: unknown) => {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Failed to delete post.') });
+    }
+  });
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM);
+    setMediaPreview({ bannerImage: null, metaImage: null });
+    setFormError(null);
+    setEditingId(null);
+  };
+
+  const openCreateModal = () => {
+    resetForm();
+    setFormMode('create');
+    setIsModalOpen(true);
+  };
+
+  const openEditModal = (post: BlogPost) => {
+    setForm({
+      title: post.title,
+      slug: post.slug,
+      categoryId: post.categoryId,
+      description: post.description,
+      published: post.published,
+      bannerImage: post.bannerImage ?? null,
+      metaTitle: post.metaTitle ?? '',
+      metaDescription: post.metaDescription ?? '',
+      metaKeywords: post.metaKeywords ?? '',
+      metaImage: post.metaImage ?? null
+    });
+    setMediaPreview({
+      bannerImage: buildMediaUrl(post.bannerImage),
+      metaImage: buildMediaUrl(post.metaImage)
+    });
+    setFormError(null);
+    setEditingId(post.id);
+    setFormMode('edit');
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleFileUpload = async (file: File, target: 'bannerImage' | 'metaImage') => {
+    setMediaUploading((prev) => ({ ...prev, [target]: true }));
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const { data } = await api.post<BlogMediaUploadResponse>('/blog/media', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
+      setForm((prev) => ({ ...prev, [target]: data.key }));
+      setMediaPreview((prev) => ({ ...prev, [target]: data.url }));
+      notify({ type: 'success', message: 'Media uploaded successfully.' });
+    } catch (error) {
+      notify({ type: 'error', message: extractErrorMessage(error, 'Failed to upload media.') });
+    } finally {
+      setMediaUploading((prev) => ({ ...prev, [target]: false }));
+    }
+  };
+
+  const handleBannerFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      void handleFileUpload(file, 'bannerImage');
+    }
+  };
+
+  const handleMetaFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      void handleFileUpload(file, 'metaImage');
+    }
+  };
+
+  const validateForm = (): boolean => {
+    if (!form.title.trim()) {
+      setFormError('Title is required.');
+      return false;
+    }
+    if (form.categoryId === null) {
+      setFormError('Please select a category.');
+      return false;
+    }
+    if (!form.description || stripHtml(form.description).length === 0) {
+      setFormError('Post content cannot be empty.');
+      return false;
+    }
+    setFormError(null);
+    return true;
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForm()) {
+      return;
+    }
+    const payload: BlogPostPayload = {
+      title: form.title.trim(),
+      slug: form.slug.trim(),
+      categoryId: form.categoryId as number,
+      description: form.description,
+      published: form.published,
+      bannerImage: form.bannerImage,
+      metaTitle: form.metaTitle.trim(),
+      metaDescription: form.metaDescription.trim(),
+      metaKeywords: form.metaKeywords.trim(),
+      metaImage: form.metaImage
+    };
+    try {
+      if (formMode === 'create') {
+        await createMutation.mutateAsync(payload);
+      } else if (editingId != null) {
+        await updateMutation.mutateAsync({ id: editingId, payload });
+      }
+      closeModal();
+    } catch (error) {
+      setFormError(extractErrorMessage(error, 'Failed to save post.'));
+    }
+  };
+
+  const handleDelete = async (post: BlogPost) => {
+    if (!canDelete) {
+      return;
+    }
+    const confirmed = window.confirm(`Delete the post "${post.title}"? This action cannot be undone.`);
+    if (!confirmed) {
+      return;
+    }
+    await deleteMutation.mutateAsync(post.id);
+  };
+
+  const totalPages = postsQuery.data?.totalPages ?? 0;
+  const totalElements = postsQuery.data?.totalElements ?? 0;
+  const pageCount = postsQuery.data?.content.length ?? 0;
+  const showingFrom = totalElements === 0 ? 0 : page * DEFAULT_PAGE_SIZE + 1;
+  const showingTo = totalElements === 0 ? 0 : page * DEFAULT_PAGE_SIZE + pageCount;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800">Blog Posts</h1>
+          <p className="text-sm text-slate-500">
+            Manage rich blog content with SEO metadata and visual assets.
+          </p>
+        </div>
+        {canCreate && (
+          <button
+            type="button"
+            onClick={openCreateModal}
+            className="self-start rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-600"
+          >
+            New Post
+          </button>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-col gap-4 border-b border-slate-200 p-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center">
+            <input
+              type="search"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+              placeholder="Search posts"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 sm:max-w-xs"
+            />
+            <select
+              value={categoryFilter === 'all' ? 'all' : String(categoryFilter)}
+              onChange={(event) => {
+                const value = event.target.value;
+                setCategoryFilter(value === 'all' ? 'all' : Number(value));
+              }}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 sm:max-w-xs"
+            >
+              <option value="all">All categories</option>
+              {categoriesQuery.data?.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as typeof statusFilter)}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 sm:max-w-xs"
+            >
+              <option value="all">All statuses</option>
+              <option value="published">Published</option>
+              <option value="draft">Draft</option>
+            </select>
+          </div>
+          <div className="text-sm text-slate-500">Page {page + 1} of {Math.max(totalPages, 1)}</div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Title</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Category</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Status</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600">Updated</th>
+                {(canUpdate || canDelete) && <th className="px-4 py-3 text-right font-medium text-slate-600">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {postsQuery.isLoading && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-slate-500">
+                    Loading posts…
+                  </td>
+                </tr>
+              )}
+              {!postsQuery.isLoading && postsQuery.data?.content.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-slate-500">
+                    No posts match your filters.
+                  </td>
+                </tr>
+              )}
+              {postsQuery.data?.content.map((post) => (
+                <tr key={post.id} className="divide-x divide-slate-100">
+                  <td className="px-4 py-3">
+                    <div className="flex flex-col">
+                      <span className="font-medium text-slate-700">{post.title}</span>
+                      <span className="text-xs text-slate-400">/{post.slug}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-slate-500">{post.categoryName}</td>
+                  <td className="px-4 py-3">
+                    {post.published ? (
+                      <span className="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-600">
+                        Published
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                        Draft
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-slate-500">
+                    {post.updatedAt ? new Date(post.updatedAt).toLocaleString() : '—'}
+                  </td>
+                  {(canUpdate || canDelete) && (
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end gap-2">
+                        {canUpdate && (
+                          <button
+                            type="button"
+                            onClick={() => openEditModal(post)}
+                            className="rounded-lg border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 transition hover:border-primary hover:text-primary"
+                          >
+                            Edit
+                          </button>
+                        )}
+                        {canDelete && (
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(post)}
+                            className="rounded-lg border border-rose-200 px-3 py-1 text-xs font-medium text-rose-500 transition hover:bg-rose-50"
+                          >
+                            Delete
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex items-center justify-between border-t border-slate-200 px-4 py-3 text-sm text-slate-600">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+            disabled={page === 0 || postsQuery.isLoading}
+            className="rounded-lg border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-40 hover:border-primary hover:text-primary"
+          >
+            Previous
+          </button>
+          <span>
+            Showing {showingFrom}-{showingTo} of {totalElements}
+          </span>
+          <button
+            type="button"
+            onClick={() =>
+              setPage((prev) =>
+                postsQuery.data && prev < postsQuery.data.totalPages - 1 ? prev + 1 : prev
+              )
+            }
+            disabled={
+              postsQuery.isLoading || (postsQuery.data ? page >= postsQuery.data.totalPages - 1 : true)
+            }
+            className="rounded-lg border border-slate-200 px-3 py-1 transition disabled:cursor-not-allowed disabled:opacity-40 hover:border-primary hover:text-primary"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+
+      {isModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4">
+          <div className="h-[90vh] w-full max-w-4xl overflow-hidden rounded-2xl bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800">
+                  {formMode === 'create' ? 'Create Post' : 'Edit Post'}
+                </h2>
+                <p className="text-sm text-slate-500">
+                  Craft engaging content and optimize metadata for search visibility.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  closeModal();
+                }}
+                className="rounded-full p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+              >
+                <span className="sr-only">Close</span>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} className="h-5 w-5">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="m6 6 12 12M18 6 6 18" />
+                </svg>
+              </button>
+            </div>
+            <div className="h-[calc(90vh-160px)] overflow-y-auto px-6 py-6">
+              <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+                <div className="space-y-5">
+                  <div>
+                    <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="post-title">
+                      Title
+                    </label>
+                    <input
+                      id="post-title"
+                      type="text"
+                      value={form.title}
+                      onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+                      className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                      placeholder="Enter a descriptive title"
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="post-slug">
+                        Slug <span className="text-xs font-normal text-slate-400">(optional)</span>
+                      </label>
+                      <input
+                        id="post-slug"
+                        type="text"
+                        value={form.slug}
+                        onChange={(event) => setForm((prev) => ({ ...prev, slug: event.target.value }))}
+                        className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                        placeholder="feature-announcement"
+                      />
+                    </div>
+                    <div>
+                      <label className="mb-1 block text-sm font-medium text-slate-700" htmlFor="post-category">
+                        Category
+                      </label>
+                      <select
+                        id="post-category"
+                      value={form.categoryId === null ? '' : String(form.categoryId)}
+                      onChange={(event) =>
+                        setForm((prev) => ({
+                          ...prev,
+                          categoryId: event.target.value ? Number(event.target.value) : null
+                        }))
+                      }
+                      className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                    >
+                      <option value="">Select a category</option>
+                        {categoriesQuery.data?.map((category) => (
+                          <option key={category.id} value={category.id}>
+                            {category.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <label className="text-sm font-medium text-slate-700">Content</label>
+                      <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-600">
+                        <input
+                          type="checkbox"
+                          checked={form.published}
+                          onChange={(event) => setForm((prev) => ({ ...prev, published: event.target.checked }))}
+                          className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                        />
+                        Publish immediately
+                      </label>
+                    </div>
+                    <RichTextEditor
+                      value={form.description}
+                      onChange={(value) => setForm((prev) => ({ ...prev, description: value }))}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-5">
+                  <div className="rounded-xl border border-slate-200 p-4">
+                    <h3 className="mb-3 text-sm font-semibold text-slate-700">Banner Image</h3>
+                    <div className="space-y-3">
+                      {mediaPreview.bannerImage ? (
+                        <img
+                          src={mediaPreview.bannerImage}
+                          alt="Banner preview"
+                          className="h-40 w-full rounded-lg object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-40 w-full items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 text-sm text-slate-400">
+                          No banner selected
+                        </div>
+                      )}
+                      <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-xs font-medium text-slate-600 transition hover:border-primary hover:text-primary">
+                        <input
+                          type="file"
+                          accept="image/*"
+                          className="hidden"
+                          onChange={handleBannerFile}
+                          disabled={mediaUploading.bannerImage}
+                        />
+                        {mediaUploading.bannerImage ? 'Uploading…' : 'Upload banner'}
+                      </label>
+                    </div>
+                  </div>
+                  <div className="rounded-xl border border-slate-200 p-4">
+                    <h3 className="mb-3 text-sm font-semibold text-slate-700">SEO Metadata</h3>
+                    <div className="space-y-3">
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-slate-500" htmlFor="meta-title">
+                          Meta Title
+                        </label>
+                        <input
+                          id="meta-title"
+                          type="text"
+                          value={form.metaTitle}
+                          onChange={(event) => setForm((prev) => ({ ...prev, metaTitle: event.target.value }))}
+                          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                          placeholder="Title displayed in search results"
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-slate-500" htmlFor="meta-description">
+                          Meta Description
+                        </label>
+                        <textarea
+                          id="meta-description"
+                          value={form.metaDescription}
+                          onChange={(event) => setForm((prev) => ({ ...prev, metaDescription: event.target.value }))}
+                          rows={3}
+                          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                          placeholder="Short summary for search engines"
+                        />
+                      </div>
+                      <div>
+                        <label className="mb-1 block text-xs font-medium text-slate-500" htmlFor="meta-keywords">
+                          Meta Keywords
+                        </label>
+                        <input
+                          id="meta-keywords"
+                          type="text"
+                          value={form.metaKeywords}
+                          onChange={(event) => setForm((prev) => ({ ...prev, metaKeywords: event.target.value }))}
+                          className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                          placeholder="keyword one, keyword two"
+                        />
+                      </div>
+                      <div className="space-y-3">
+                        <p className="text-xs font-medium text-slate-500">Meta Image</p>
+                        {mediaPreview.metaImage ? (
+                          <img
+                            src={mediaPreview.metaImage}
+                            alt="Meta preview"
+                            className="h-32 w-full rounded-lg object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-32 w-full items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 text-sm text-slate-400">
+                            No meta image selected
+                          </div>
+                        )}
+                        <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-xs font-medium text-slate-600 transition hover:border-primary hover:text-primary">
+                          <input
+                            type="file"
+                            accept="image/*"
+                            className="hidden"
+                            onChange={handleMetaFile}
+                            disabled={mediaUploading.metaImage}
+                          />
+                          {mediaUploading.metaImage ? 'Uploading…' : 'Upload meta image'}
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              {formError && (
+                <div className="mt-6 rounded-lg bg-rose-50 px-4 py-3 text-sm text-rose-600">{formError}</div>
+              )}
+            </div>
+            <div className="flex items-center justify-end gap-3 border-t border-slate-200 px-6 py-4">
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-600"
+                disabled={createMutation.isPending || updateMutation.isPending}
+              >
+                {createMutation.isPending || updateMutation.isPending ? 'Saving…' : 'Save Post'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BlogPostsPage;

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -32,16 +32,11 @@ type FolderModalState = {
   parentId: number | null;
 };
 
-type FolderTreeNode = {
-  key: string;
+type OwnerSummary = {
+  ownerId: number;
   label: string;
-  folderId: number | null;
-  ownerId: number | null;
-  depth: number;
-  children: FolderTreeNode[];
   description?: string;
-  isSynthetic: boolean;
-  isSelectable: boolean;
+  ownerKey?: string | null;
 };
 
 type DetailsModalState = {
@@ -97,140 +92,6 @@ const resolveFileUrl = (id: number, token?: string | null) => {
   return url.toString();
 };
 
-const buildFolderTree = (
-  folders: GalleryFolder[],
-  currentUserId: number | null,
-  canViewAll: boolean
-): FolderTreeNode[] => {
-  const concreteFolders = folders.filter((folder): folder is GalleryFolder & { id: number } => folder.id !== null);
-  const grouped = new Map<number | null, (GalleryFolder & { id: number })[]>();
-
-  concreteFolders.forEach((folder) => {
-    const ownerId = folder.ownerId ?? null;
-    const existing = grouped.get(ownerId);
-    if (existing) {
-      existing.push(folder);
-    } else {
-      grouped.set(ownerId, [folder]);
-    }
-  });
-
-  if (currentUserId !== null && !grouped.has(currentUserId)) {
-    grouped.set(currentUserId, []);
-  }
-
-  const buildHierarchy = (
-    items: (GalleryFolder & { id: number })[],
-    parentId: number | null,
-    depth: number
-  ): FolderTreeNode[] => {
-    const children = items.filter((item) => (item.parentId ?? null) === parentId);
-    children.sort((a, b) => a.name.localeCompare(b.name));
-    return children.map((child) => ({
-      key: `folder-${child.id}`,
-      label: child.name,
-      folderId: child.id,
-      ownerId: child.ownerId ?? null,
-      depth,
-      description: undefined,
-      isSynthetic: false,
-      isSelectable: true,
-      children: buildHierarchy(items, child.id, depth + 1)
-    }));
-  };
-
-  const resolveOwnerMeta = (ownerId: number | null) => {
-    const items = grouped.get(ownerId) ?? [];
-    const sample = items[0];
-    if (ownerId === null) {
-      return {
-        label: canViewAll ? 'Shared Files' : 'My Files',
-        description: canViewAll ? 'Files without a specific owner' : undefined
-      };
-    }
-    if (currentUserId !== null && ownerId === currentUserId) {
-      return {
-        label: 'My Files',
-        description: sample?.ownerEmail ?? sample?.ownerName ?? undefined
-      };
-    }
-    return {
-      label: sample?.ownerKey ?? sample?.ownerEmail ?? sample?.ownerName ?? `User ${ownerId}`,
-      description: sample?.ownerEmail ?? sample?.ownerName ?? undefined
-    };
-  };
-
-  const createOwnerNode = (ownerId: number | null, depth: number): FolderTreeNode => {
-    const meta = resolveOwnerMeta(ownerId);
-    const items = grouped.get(ownerId) ?? [];
-    return {
-      key: ownerId === null ? 'owner-unassigned' : `owner-${ownerId}`,
-      label: meta.label,
-      folderId: null,
-      ownerId,
-      depth,
-      description: meta.description,
-      isSynthetic: true,
-      isSelectable: ownerId !== null,
-      children: buildHierarchy(items, null, depth + 1)
-    };
-  };
-
-  const rootNode: FolderTreeNode = {
-    key: 'scope-all-files',
-    label: 'All Files',
-    folderId: null,
-    ownerId: null,
-    depth: 0,
-    description: canViewAll ? 'Everything that has been uploaded' : 'Your personal workspace',
-    isSynthetic: true,
-    isSelectable: true,
-    children: []
-  };
-
-  const rootChildren: FolderTreeNode[] = [];
-
-  if (currentUserId !== null || !canViewAll) {
-    const myItems = grouped.get(currentUserId ?? null) ?? [];
-    rootChildren.push({
-      key: 'scope-my-files',
-      label: 'My Files',
-      folderId: null,
-      ownerId: currentUserId ?? null,
-      depth: 1,
-      description: canViewAll ? 'Files that belong to you' : undefined,
-      isSynthetic: true,
-      isSelectable: true,
-      children: buildHierarchy(myItems, null, 2)
-    });
-  }
-
-  if (canViewAll) {
-    const otherOwnerIds = Array.from(grouped.keys()).filter((ownerId) => ownerId !== currentUserId);
-    const otherNodes = otherOwnerIds.map((ownerId) => createOwnerNode(ownerId, 2));
-    otherNodes.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
-    if (otherNodes.length > 0) {
-      rootChildren.push({
-        key: 'scope-all-users',
-        label: 'All Users Files',
-        folderId: null,
-        ownerId: null,
-        depth: 1,
-        description: 'All other users',
-        isSynthetic: true,
-        isSelectable: false,
-        children: otherNodes.map((node) => ({
-          ...node,
-          depth: 2
-        }))
-      });
-    }
-  }
-
-  rootNode.children = rootChildren;
-  return [rootNode];
-};
-
 const GalleryPage = () => {
   const queryClient = useQueryClient();
   const { notify } = useToast();
@@ -241,7 +102,7 @@ const GalleryPage = () => {
   const [pageSize, setPageSize] = useState(20);
   const [sortValue, setSortValue] = useState<SortOptionValue>('newest');
   const [folderFilter, setFolderFilter] = useState<number | null>(null);
-  const [ownerFilter, setOwnerFilter] = useState<number | null>(null);
+  const [ownerFilter, setOwnerFilter] = useState<number | null>(user?.id ?? null);
   const [searchDraft, setSearchDraft] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [uploaderFilter, setUploaderFilter] = useState('');
@@ -249,19 +110,37 @@ const GalleryPage = () => {
   const [editModal, setEditModal] = useState<EditModalState | null>(null);
   const [folderModal, setFolderModal] = useState<FolderModalState | null>(null);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(() => new Set());
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [activeMenuId, setActiveMenuId] = useState<number | null>(null);
+  const [activeFolderMenuId, setActiveFolderMenuId] = useState<number | null>(null);
   const [detailsModal, setDetailsModal] = useState<DetailsModalState | null>(null);
+  const [isSharedExpanded, setIsSharedExpanded] = useState(false);
+  const [sharedSearch, setSharedSearch] = useState('');
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
 
   const granted = (grantedPermissions as PermissionKey[]) ?? [];
   const currentUserId = user?.id ?? null;
+  const currentUserName = user?.fullName ?? null;
+  const currentUserEmail = user?.email ?? null;
 
   const canUpload = useMemo(() => hasAnyPermission(granted, ['GALLERY_CREATE']), [granted]);
   const canEdit = useMemo(() => hasAnyPermission(granted, ['GALLERY_EDIT_ALL']), [granted]);
   const canDeleteAll = useMemo(() => hasAnyPermission(granted, ['GALLERY_DELETE_ALL']), [granted]);
   const canDeleteOwn = useMemo(() => hasAnyPermission(granted, ['GALLERY_DELETE_OWN']), [granted]);
   const canViewAll = useMemo(() => hasAnyPermission(granted, ['GALLERY_VIEW_ALL']), [granted]);
+  const canManageFolders = useMemo(() => canUpload || canEdit, [canUpload, canEdit]);
+
+  useEffect(() => {
+    if (!canViewAll) {
+      if (ownerFilter !== currentUserId) {
+        setOwnerFilter(currentUserId);
+      }
+      return;
+    }
+    if (ownerFilter === null && currentUserId !== null) {
+      setOwnerFilter(currentUserId);
+    }
+  }, [canViewAll, currentUserId, ownerFilter]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -275,7 +154,10 @@ const GalleryPage = () => {
     if (typeof window === 'undefined') {
       return;
     }
-    const handleDocumentClick = () => setActiveMenuId(null);
+    const handleDocumentClick = () => {
+      setActiveMenuId(null);
+      setActiveFolderMenuId(null);
+    };
     document.addEventListener('click', handleDocumentClick);
     return () => {
       document.removeEventListener('click', handleDocumentClick);
@@ -318,8 +200,10 @@ const GalleryPage = () => {
       };
       if (folderFilter !== null) {
         params.folderId = folderFilter;
-      } else if (canViewAll && ownerFilter !== null) {
-        params.uploaderId = ownerFilter;
+      }
+      const effectiveOwnerId = canViewAll ? ownerFilter : currentUserId;
+      if (effectiveOwnerId !== null) {
+        params.ownerId = effectiveOwnerId;
       }
       if (searchTerm) {
         params.search = searchTerm;
@@ -339,13 +223,22 @@ const GalleryPage = () => {
 
   const uploadFiles = useMutation({
     mutationFn: async (files: File[]) => {
+      setUploadProgress(0);
       const formData = new FormData();
       files.forEach((file) => formData.append('files', file));
       if (folderFilter !== null) {
         formData.append('folderId', folderFilter.toString());
       }
       const { data } = await api.post<GalleryFile[]>('/gallery/files', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' }
+        headers: { 'Content-Type': 'multipart/form-data' },
+        onUploadProgress: (event) => {
+          if (!event.total) {
+            setUploadProgress((previous) => (previous === null ? 0 : previous));
+            return;
+          }
+          const progress = Math.round((event.loaded / event.total) * 100);
+          setUploadProgress(progress);
+        }
       });
       return data;
     },
@@ -353,9 +246,11 @@ const GalleryPage = () => {
       notify({ type: 'success', message: uploaded.length === 1 ? 'File uploaded successfully.' : 'Files uploaded successfully.' });
       invalidateGallery();
       setSelectedIds([]);
+      setUploadProgress(null);
     },
     onError: () => {
       notify({ type: 'error', message: 'Unable to upload files. Please check the allowed file types.' });
+      setUploadProgress(null);
     }
   });
 
@@ -410,7 +305,40 @@ const GalleryPage = () => {
     }
   });
 
-  const files = filesQuery.data?.content ?? [];
+  const deleteFolder = useMutation({
+    mutationFn: async (folderId: number) => {
+      await api.delete(`/gallery/folders/${folderId}`);
+    },
+    onSuccess: () => {
+      notify({ type: 'success', message: 'Folder deleted successfully.' });
+      queryClient.invalidateQueries({ queryKey: ['gallery', 'folders'] });
+      invalidateGallery();
+      setSelectedIds([]);
+      setActiveFolderMenuId(null);
+    },
+    onError: (error: unknown) => {
+      let message: string | undefined;
+      if (typeof error === 'object' && error !== null && 'response' in error) {
+        const response = (error as { response?: unknown }).response;
+        if (response && typeof response === 'object' && 'data' in response) {
+          const data = (response as { data?: unknown }).data;
+          if (data && typeof data === 'object' && 'message' in data && typeof (data as { message?: unknown }).message === 'string') {
+            message = (data as { message: string }).message;
+          }
+        }
+      }
+      notify({ type: 'error', message: message ?? 'Unable to delete the folder. Ensure it is empty first.' });
+      setActiveFolderMenuId(null);
+    }
+  });
+
+  const queryFiles = filesQuery.data?.content ?? [];
+  const files = useMemo(() => {
+    if (folderFilter === null) {
+      return queryFiles;
+    }
+    return queryFiles.filter((file) => (file.folderId ?? null) === folderFilter);
+  }, [queryFiles, folderFilter]);
   const totalPages = filesQuery.data?.totalPages ?? 0;
 
   const allSelected = files.length > 0 && selectedIds.length === files.length;
@@ -445,10 +373,13 @@ const GalleryPage = () => {
     if (!selectedIds.length) {
       return;
     }
+    setActiveMenuId(null);
+    setActiveFolderMenuId(null);
     deleteFiles.mutate(selectedIds);
   };
 
   const handleDeleteSingle = (id: number) => {
+    setActiveMenuId(null);
     deleteFiles.mutate([id]);
   };
 
@@ -515,6 +446,42 @@ const GalleryPage = () => {
     </>
   );
 
+  const renderFolderMenu = (folder: GalleryFolder & { id: number }) => {
+    const canDeleteFolder = canManageFolders && !folder.root;
+    const isDeleting = deleteFolder.isPending && activeFolderMenuId === folder.id;
+    return (
+      <>
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            setActiveFolderMenuId(null);
+            setActiveMenuId(null);
+            handleFolderOpen(folder.id);
+          }}
+          className="w-full rounded-lg px-3 py-2 text-left text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-primary"
+        >
+          Open
+        </button>
+        {canDeleteFolder && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setActiveFolderMenuId(null);
+              setActiveMenuId(null);
+              deleteFolder.mutate(folder.id);
+            }}
+            disabled={isDeleting}
+            className="w-full rounded-lg px-3 py-2 text-left text-sm font-medium text-rose-600 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </button>
+        )}
+      </>
+    );
+  };
+
   const foldersData = foldersQuery.data ?? [];
   const folderMap = useMemo(() => {
     const map = new Map<number, GalleryFolder & { id: number }>();
@@ -526,6 +493,51 @@ const GalleryPage = () => {
     return map;
   }, [foldersData]);
 
+  const ownerSummaryMap = useMemo(() => {
+    const map = new Map<number, OwnerSummary>();
+    foldersData.forEach((folder) => {
+      if (folder.ownerId === null) {
+        return;
+      }
+      if (!map.has(folder.ownerId)) {
+        map.set(folder.ownerId, {
+          ownerId: folder.ownerId,
+          label: folder.ownerName ?? folder.ownerEmail ?? folder.ownerKey ?? `User ${folder.ownerId}`,
+          description: folder.ownerEmail ?? folder.ownerName ?? undefined,
+          ownerKey: folder.ownerKey ?? null
+        });
+      }
+    });
+    if (currentUserId !== null && !map.has(currentUserId)) {
+      map.set(currentUserId, {
+        ownerId: currentUserId,
+        label: currentUserName ?? currentUserEmail ?? `User ${currentUserId}`,
+        description: currentUserEmail ?? undefined,
+        ownerKey: null
+      });
+    }
+    return map;
+  }, [foldersData, currentUserId, currentUserName, currentUserEmail]);
+
+  const sharedOwners = useMemo(() => {
+    const owners = Array.from(ownerSummaryMap.values()).filter((summary) => summary.ownerId !== currentUserId);
+    owners.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+    return owners;
+  }, [ownerSummaryMap, currentUserId]);
+
+  const filteredSharedOwners = useMemo(() => {
+    const term = sharedSearch.trim().toLowerCase();
+    if (!term) {
+      return sharedOwners;
+    }
+    return sharedOwners.filter((owner) => {
+      const values = [owner.label, owner.description ?? '', owner.ownerKey ?? '', owner.ownerId.toString()].map((value) =>
+        value.toLowerCase()
+      );
+      return values.some((value) => value.includes(term));
+    });
+  }, [sharedOwners, sharedSearch]);
+
   const resolveOwnerLabel = useCallback(
     (ownerId: number | null) => {
       if (ownerId === null) {
@@ -534,12 +546,10 @@ const GalleryPage = () => {
       if (currentUserId !== null && ownerId === currentUserId) {
         return 'My Files';
       }
-      const match = foldersData.find(
-        (candidate): candidate is GalleryFolder & { id: number } => candidate.id !== null && candidate.ownerId === ownerId
-      );
-      return match?.ownerKey ?? match?.ownerEmail ?? match?.ownerName ?? `User ${ownerId}`;
+      const summary = ownerSummaryMap.get(ownerId);
+      return summary?.label ?? `User ${ownerId}`;
     },
-    [canViewAll, currentUserId, foldersData]
+    [canViewAll, currentUserId, ownerSummaryMap]
   );
 
   const resolveFolderName = useCallback((folderId?: number | null) => {
@@ -582,32 +592,13 @@ const GalleryPage = () => {
       </option>
     ));
 
-  const folderTree = useMemo(() => buildFolderTree(foldersData, currentUserId, canViewAll), [foldersData, currentUserId, canViewAll]);
-
-  useEffect(() => {
-    setExpandedNodes((previous) => {
-      const next = new Set(previous);
-      const expandInitial = (nodes: FolderTreeNode[]) => {
-        nodes.forEach((node) => {
-          if (node.children.length > 0 && node.depth <= 1) {
-            next.add(node.key);
-          }
-          if (node.children.length > 0) {
-            expandInitial(node.children);
-          }
-        });
-      };
-      expandInitial(folderTree);
-      return next;
-    });
-  }, [folderTree]);
-
   useEffect(() => {
     setIsSidebarOpen(false);
   }, [folderFilter, ownerFilter]);
 
   useEffect(() => {
     setActiveMenuId(null);
+    setActiveFolderMenuId(null);
   }, [viewMode, files]);
 
   const activeOwnerId = useMemo(() => {
@@ -621,15 +612,8 @@ const GalleryPage = () => {
     return currentUserId;
   }, [folderFilter, folderMap, canViewAll, ownerFilter, currentUserId]);
 
-  const shouldFilterByOwner = useMemo(() => {
-    if (folderFilter !== null) {
-      return true;
-    }
-    if (!canViewAll) {
-      return true;
-    }
-    return ownerFilter !== null;
-  }, [folderFilter, canViewAll, ownerFilter]);
+  const isViewingMyFiles = currentUserId !== null ? activeOwnerId === currentUserId : activeOwnerId === null;
+  const selectedSharedOwnerId = currentUserId !== null && activeOwnerId === currentUserId ? null : activeOwnerId;
 
   const visibleFolders = useMemo(() => {
     const targetParentId = folderFilter ?? null;
@@ -638,184 +622,104 @@ const GalleryPage = () => {
         (folder): folder is GalleryFolder & { id: number } =>
           folder.id !== null &&
           (folder.parentId ?? null) === targetParentId &&
-          (!shouldFilterByOwner || (folder.ownerId ?? null) === (activeOwnerId ?? null))
+          (activeOwnerId === null || (folder.ownerId ?? null) === activeOwnerId)
       )
       .sort((a, b) => a.name.localeCompare(b.name));
-  }, [foldersData, folderFilter, shouldFilterByOwner, activeOwnerId]);
+  }, [foldersData, folderFilter, activeOwnerId]);
 
   const headerTitle = useMemo(() => {
     if (folderFilter !== null) {
       const folder = folderMap.get(folderFilter);
       return folder?.name ?? 'Folder';
     }
-    if (canViewAll) {
-      if (ownerFilter !== null) {
-        if (currentUserId !== null && ownerFilter === currentUserId) {
-          return 'My Files';
-        }
-        const ownerName = resolveOwnerLabel(ownerFilter);
-        return `${ownerName}'s Files`;
+    if (activeOwnerId !== null) {
+      if (currentUserId !== null && activeOwnerId === currentUserId) {
+        return 'My Files';
       }
-      return 'All Files';
+      const ownerName = resolveOwnerLabel(activeOwnerId);
+      return `${ownerName}'s Files`;
     }
-    return 'My Files';
-  }, [folderFilter, folderMap, canViewAll, ownerFilter, resolveOwnerLabel, currentUserId]);
+    return canViewAll ? 'Shared Files' : 'My Files';
+  }, [folderFilter, folderMap, activeOwnerId, currentUserId, canViewAll, resolveOwnerLabel]);
 
   const headerSubtitle = useMemo(() => {
     if (folderFilter !== null) {
       return resolveFolderName(folderFilter);
     }
-    if (canViewAll) {
-      if (ownerFilter !== null) {
-        return currentUserId !== null && ownerFilter === currentUserId
-          ? 'Your personal workspace'
-          : 'Files owned by the selected user';
-      }
-      return 'Everything that has been uploaded across the workspace';
+    if (activeOwnerId !== null) {
+      return currentUserId !== null && activeOwnerId === currentUserId
+        ? 'Your personal workspace'
+        : 'Files owned by the selected user';
     }
-    return 'All of the files and folders you own';
-  }, [folderFilter, resolveFolderName, canViewAll, ownerFilter, currentUserId]);
+    return canViewAll
+      ? 'Everything that has been uploaded across the workspace'
+      : 'All of the files and folders you own';
+  }, [folderFilter, resolveFolderName, activeOwnerId, currentUserId, canViewAll]);
 
   const breadcrumbs = useMemo(() => {
-    const crumbs: { label: string; folderId: number | null; ownerId: number | null }[] = [
-      { label: 'All Files', folderId: null, ownerId: null }
-    ];
+    const crumbs: { label: string; folderId: number | null; ownerId: number | null }[] = [];
+    crumbs.push({ label: 'My Files', folderId: null, ownerId: currentUserId });
 
-    if (folderFilter !== null) {
+    const appendFolderTrail = (startId: number) => {
       const stack: (GalleryFolder & { id: number })[] = [];
-      let current = folderMap.get(folderFilter);
-      const ownerId = current?.ownerId ?? null;
+      let current = folderMap.get(startId);
       while (current) {
         stack.unshift(current);
         if (current.parentId === null) {
           break;
         }
-        const parentId = current.parentId;
-        current = parentId !== null ? folderMap.get(parentId) : undefined;
-      }
-      if (canViewAll && ownerId !== null) {
-        crumbs.push({ label: resolveOwnerLabel(ownerId), folderId: null, ownerId });
+        current = current.parentId !== null ? folderMap.get(current.parentId) : undefined;
       }
       stack.forEach((folder) => {
         crumbs.push({ label: folder.name, folderId: folder.id, ownerId: folder.ownerId ?? null });
       });
+    };
+
+    if (folderFilter !== null) {
+      const folder = folderMap.get(folderFilter);
+      const ownerId = folder?.ownerId ?? null;
+      if (canViewAll && ownerId !== null && (currentUserId === null || ownerId !== currentUserId)) {
+        crumbs.push({ label: resolveOwnerLabel(ownerId), folderId: null, ownerId });
+      } else if (canViewAll && activeOwnerId !== null && (currentUserId === null || activeOwnerId !== currentUserId)) {
+        crumbs.push({ label: resolveOwnerLabel(activeOwnerId), folderId: null, ownerId: activeOwnerId });
+      }
+      appendFolderTrail(folderFilter);
       return crumbs;
     }
 
-    if (canViewAll && ownerFilter !== null) {
-      crumbs.push({ label: resolveOwnerLabel(ownerFilter), folderId: null, ownerId: ownerFilter });
+    if (canViewAll && activeOwnerId !== null && (currentUserId === null || activeOwnerId !== currentUserId)) {
+      crumbs.push({ label: resolveOwnerLabel(activeOwnerId), folderId: null, ownerId: activeOwnerId });
     }
 
     return crumbs;
-  }, [folderFilter, ownerFilter, folderMap, canViewAll, resolveOwnerLabel]);
+  }, [folderFilter, folderMap, canViewAll, activeOwnerId, resolveOwnerLabel, currentUserId]);
 
-  const isAllScopeSelected = folderFilter === null && ownerFilter === null;
+  const handleSelectMyFiles = () => {
+    setOwnerFilter(currentUserId);
+    setFolderFilter(null);
+    setSelectedIds([]);
+    setIsSidebarOpen(false);
+    setActiveFolderMenuId(null);
+    setActiveMenuId(null);
+  };
+
+  const handleSelectSharedOwner = (ownerId: number) => {
+    setOwnerFilter(ownerId);
+    setFolderFilter(null);
+    setSelectedIds([]);
+    setIsSidebarOpen(false);
+    setActiveFolderMenuId(null);
+    setActiveMenuId(null);
+  };
 
   const handleFolderOpen = (id: number) => {
     setFolderFilter(id);
-    setOwnerFilter(null);
+    const folder = folderMap.get(id);
+    const ownerIdForFolder = folder?.ownerId ?? (canViewAll ? ownerFilter : currentUserId) ?? null;
+    setOwnerFilter(ownerIdForFolder);
     setSelectedIds([]);
+    setActiveFolderMenuId(null);
   };
-
-  const handleNodeSelection = (node: FolderTreeNode) => {
-    if (node.isSelectable === false) {
-      return;
-    }
-    if (node.folderId !== null) {
-      setFolderFilter(node.folderId);
-      setOwnerFilter(null);
-    } else {
-      setOwnerFilter(canViewAll ? node.ownerId ?? null : null);
-      setFolderFilter(null);
-    }
-    setSelectedIds([]);
-    setIsSidebarOpen(false);
-  };
-
-  const toggleNodeExpansion = (node: FolderTreeNode) => {
-    if (!node.children.length) {
-      return;
-    }
-    setExpandedNodes((previous) => {
-      const next = new Set(previous);
-      if (next.has(node.key)) {
-        next.delete(node.key);
-      } else {
-        next.add(node.key);
-      }
-      return next;
-    });
-  };
-
-  const renderTreeNodes = (nodes: FolderTreeNode[]) =>
-    nodes.map((node) => {
-      const isFolder = node.folderId !== null;
-      const isSelectable = node.isSelectable !== false;
-      const ownerSelectionMatches = (() => {
-        if (isFolder) {
-          return false;
-        }
-        if (!canViewAll) {
-          return node.key === 'scope-my-files';
-        }
-        if (node.key === 'scope-all-files') {
-          return ownerFilter === null;
-        }
-        if (node.ownerId === null) {
-          return false;
-        }
-        return ownerFilter === node.ownerId;
-      })();
-      const isSelected =
-        isSelectable && (isFolder ? folderFilter === node.folderId : folderFilter === null && ownerSelectionMatches);
-      const hasChildren = node.children.length > 0;
-      const isExpanded = !hasChildren || expandedNodes.has(node.key);
-
-      return (
-        <div key={node.key} className="flex flex-col" style={{ marginLeft: `${node.depth * 12}px` }}>
-          <div className="flex items-center gap-1">
-            {hasChildren ? (
-              <button
-                type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  toggleNodeExpansion(node);
-                }}
-                className="flex h-6 w-6 items-center justify-center rounded-md text-xs text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
-                aria-label={isExpanded ? 'Collapse' : 'Expand'}
-              >
-                {isExpanded ? '▾' : '▸'}
-              </button>
-            ) : (
-              <span className="h-6 w-6" />
-            )}
-            <button
-              type="button"
-              onClick={() => handleNodeSelection(node)}
-              disabled={!isSelectable}
-              aria-disabled={!isSelectable}
-              className={`flex min-h-[2.5rem] flex-1 items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition ${
-                isSelected
-                  ? 'bg-primary/10 text-primary'
-                  : isSelectable
-                    ? 'text-slate-600 hover:bg-slate-100'
-                    : 'cursor-default text-slate-400'
-              }`}
-            >
-              <span className="flex flex-col">
-                <span className="inline-flex items-center gap-2">
-                  <span className="text-lg">{isFolder ? '📁' : '👤'}</span>
-                  <span className="font-medium">{node.label}</span>
-                </span>
-                {node.description && <span className="ml-6 text-xs text-slate-400">{node.description}</span>}
-              </span>
-              {hasChildren && <span className="text-xs text-slate-400">{node.children.length}</span>}
-            </button>
-          </div>
-          {hasChildren && isExpanded && <div className="ml-7 mt-1 flex flex-col gap-1">{renderTreeNodes(node.children)}</div>}
-        </div>
-      );
-    });
 
   const handleBreadcrumbClick = (folderId: number | null, ownerId: number | null, isLast: boolean) => {
     if (isLast) {
@@ -823,22 +727,22 @@ const GalleryPage = () => {
     }
     if (folderId !== null) {
       setFolderFilter(folderId);
-      setOwnerFilter(null);
+      const folder = folderMap.get(folderId);
+      const ownerIdForFolder = folder?.ownerId ?? (canViewAll ? ownerFilter : currentUserId) ?? null;
+      setOwnerFilter(ownerIdForFolder);
     } else if (ownerId !== null) {
+      if (currentUserId !== null && ownerId === currentUserId) {
+        handleSelectMyFiles();
+        return;
+      }
       setOwnerFilter(ownerId);
       setFolderFilter(null);
     } else {
-      setOwnerFilter(null);
-      setFolderFilter(null);
+      handleSelectMyFiles();
+      return;
     }
     setSelectedIds([]);
-  };
-
-  const handleResetSelection = () => {
-    setOwnerFilter(null);
-    setFolderFilter(null);
-    setSelectedIds([]);
-    setIsSidebarOpen(false);
+    setActiveFolderMenuId(null);
   };
 
 
@@ -859,6 +763,21 @@ const GalleryPage = () => {
         onChange={handleFileInputChange}
         disabled={!canUpload || uploadFiles.isPending}
       />
+
+      {uploadProgress !== null && (
+        <div className="rounded-3xl border border-primary/30 bg-primary/5 p-4 shadow-sm">
+          <div className="flex items-center justify-between text-sm font-semibold text-primary">
+            <span>Uploading files…</span>
+            <span>{Math.max(0, Math.min(uploadProgress, 100))}%</span>
+          </div>
+          <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-primary/10">
+            <div
+              className="h-full rounded-full bg-primary transition-all duration-200"
+              style={{ width: `${Math.max(0, Math.min(uploadProgress, 100))}%` }}
+            />
+          </div>
+        </div>
+      )}
 
       <div className="lg:hidden">
         <button
@@ -908,21 +827,79 @@ const GalleryPage = () => {
               </button>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={handleResetSelection}
-            className={`flex items-center gap-3 rounded-2xl px-3 py-2 text-left text-sm transition ${
-              isAllScopeSelected ? 'bg-primary/10 font-semibold text-primary' : 'text-slate-600 hover:bg-slate-100'
-            }`}
-          >
-            <span className="text-xl">🗂️</span>
-            <span>All files</span>
-          </button>
-          <div className="flex flex-1 flex-col gap-1 overflow-y-auto pr-1">
-            {folderTree.length ? (
-              renderTreeNodes(folderTree)
-            ) : (
-              <p className="px-3 py-6 text-sm text-slate-400">No folders yet. Create one to get started.</p>
+          <div className="flex flex-1 flex-col gap-3 overflow-y-auto pr-1">
+            <button
+              type="button"
+              onClick={handleSelectMyFiles}
+              className={`flex items-center justify-between rounded-2xl px-3 py-2 text-left text-sm transition ${
+                isViewingMyFiles ? 'bg-primary/10 font-semibold text-primary' : 'text-slate-600 hover:bg-slate-100'
+              }`}
+            >
+              <span className="inline-flex items-center gap-3">
+                <span className="text-xl">📁</span>
+                <span>My Files</span>
+              </span>
+              {isViewingMyFiles && <span className="text-xs uppercase tracking-wide text-primary">Active</span>}
+            </button>
+            {canViewAll && (
+              <div className="rounded-2xl border border-slate-200">
+                <button
+                  type="button"
+                  onClick={() => setIsSharedExpanded((previous) => !previous)}
+                  className={`flex w-full items-center justify-between rounded-2xl px-3 py-2 text-left text-sm font-medium transition ${
+                    selectedSharedOwnerId !== null ? 'text-primary' : 'text-slate-600 hover:bg-slate-100'
+                  }`}
+                >
+                  <span className="inline-flex items-center gap-3">
+                    <span className="text-xl">🤝</span>
+                    <span>Shared with me</span>
+                  </span>
+                  <span className="text-sm text-slate-400">{isSharedExpanded ? '▾' : '▸'}</span>
+                </button>
+                {isSharedExpanded && (
+                  <div className="space-y-3 border-t border-slate-200 px-3 py-3">
+                    <div>
+                      <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Search users</label>
+                      <input
+                        type="search"
+                        value={sharedSearch}
+                        onChange={(event) => setSharedSearch(event.target.value)}
+                        placeholder="Search by user ID"
+                        className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+                      />
+                    </div>
+                    <div className="flex max-h-64 flex-col gap-1 overflow-y-auto pr-1">
+                      {filteredSharedOwners.length ? (
+                        filteredSharedOwners.map((owner) => {
+                          const isSelected = selectedSharedOwnerId === owner.ownerId;
+                          return (
+                            <button
+                              key={owner.ownerId}
+                              type="button"
+                              onClick={() => handleSelectSharedOwner(owner.ownerId)}
+                              className={`flex items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition ${
+                                isSelected ? 'bg-primary/10 text-primary' : 'text-slate-600 hover:bg-slate-100'
+                              }`}
+                            >
+                              <span className="flex flex-col">
+                                <span className="font-medium">{owner.label}</span>
+                                {(owner.ownerKey || owner.description) && (
+                                  <span className="text-xs text-slate-400">
+                                    {[owner.ownerKey, owner.description].filter(Boolean).join(' • ')}
+                                  </span>
+                                )}
+                              </span>
+                              {isSelected && <span className="text-xs uppercase tracking-wide text-primary">Active</span>}
+                            </button>
+                          );
+                        })
+                      ) : (
+                        <p className="px-2 py-4 text-sm text-slate-400">No users found.</p>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
             )}
           </div>
         </aside>
@@ -1087,11 +1064,34 @@ const GalleryPage = () => {
                       onClick={() => handleFolderOpen(folder.id)}
                       className="group flex h-full flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-left transition hover:-translate-y-1 hover:border-primary hover:bg-white hover:shadow-lg"
                     >
-                      <div className="flex items-center justify-between">
+                      <div className="relative flex items-center justify-between gap-2">
                         <span className="text-3xl">📁</span>
-                        <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-500 shadow-sm">
-                          {resolveOwnerLabel(folder.ownerId ?? null)}
-                        </span>
+                        <div className="flex items-center gap-2">
+                          <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-500 shadow-sm">
+                            {resolveOwnerLabel(folder.ownerId ?? null)}
+                          </span>
+                          {canManageFolders && !folder.root && (
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setActiveMenuId(null);
+                                setActiveFolderMenuId((previous) => (previous === folder.id ? null : folder.id));
+                              }}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-base text-slate-500 shadow-sm transition hover:border-primary hover:text-primary"
+                            >
+                              ⋮
+                            </button>
+                          )}
+                        </div>
+                        {activeFolderMenuId === folder.id && (
+                          <div
+                            className="absolute right-0 top-10 z-20 w-48 rounded-xl border border-slate-200 bg-white p-2 shadow-xl"
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            {renderFolderMenu(folder)}
+                          </div>
+                        )}
                       </div>
                       <div className="min-w-0">
                         <p className="truncate text-sm font-semibold text-slate-900">{folder.name}</p>
@@ -1224,17 +1224,42 @@ const GalleryPage = () => {
                           <td className="px-4 py-3 text-slate-500">—</td>
                           <td className="px-4 py-3 text-slate-600">{resolveOwnerLabel(folder.ownerId ?? null)}</td>
                           <td className="px-4 py-3 text-slate-500">—</td>
-                          <td className="px-4 py-3 text-right">
-                            <button
-                              type="button"
-                              onClick={() => handleFolderOpen(folder.id)}
-                              className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-primary hover:text-primary"
-                            >
-                              Open
-                            </button>
-                          </td>
-                        </tr>
-                      ))}
+                      <td className="px-4 py-3 text-right">
+                        <div className="inline-flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleFolderOpen(folder.id)}
+                            className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-primary hover:text-primary"
+                          >
+                            Open
+                          </button>
+                          {canManageFolders && !folder.root && (
+                            <div className="relative">
+                              <button
+                                type="button"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  setActiveMenuId(null);
+                                  setActiveFolderMenuId((previous) => (previous === folder.id ? null : folder.id));
+                                }}
+                                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-lg text-slate-500 transition hover:border-primary hover:text-primary"
+                              >
+                                ⋮
+                              </button>
+                              {activeFolderMenuId === folder.id && (
+                                <div
+                                  className="absolute right-0 top-10 z-20 w-48 rounded-xl border border-slate-200 bg-white p-2 shadow-xl"
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  {renderFolderMenu(folder)}
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
                       {files.map((file) => {
                         const isOwner = currentUserId !== null && currentUserId === (file.uploadedById ?? null);
                         const canDeleteFile = canDeleteAll || (canDeleteOwn && isOwner);

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -31,7 +31,7 @@ const LoginPage = () => {
     const result = await dispatch(login({ email, password }));
     if (login.fulfilled.match(result)) {
       notify({ type: 'success', message: 'Signed in successfully.' });
-      navigate('/dashboard');
+      navigate('/admin');
     } else if (login.rejected.match(result)) {
       const message = result.payload ?? 'Unable to sign in right now.';
       setErrorMessage(message);

--- a/frontend/src/pages/PublicBlogListPage.tsx
+++ b/frontend/src/pages/PublicBlogListPage.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '../services/http';
+import type { BlogCategory, PublicBlogPost, PublicBlogPostPage } from '../types/blog';
+
+const DEFAULT_PAGE_SIZE = 9;
+
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim();
+
+const PublicBlogListPage = () => {
+  const [page, setPage] = useState(0);
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<'all' | string>('all');
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearch(searchDraft.trim());
+      setPage(0);
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [searchDraft]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [categoryFilter]);
+
+  const categoriesQuery = useQuery<BlogCategory[]>({
+    queryKey: ['public', 'blog', 'categories'],
+    queryFn: async () => {
+      const { data } = await api.get<BlogCategory[]>('/blog/public/categories');
+      return data;
+    }
+  });
+
+  const postsQuery = useQuery<PublicBlogPostPage>({
+    queryKey: ['public', 'blog', 'posts', { page, search, categoryFilter }],
+    queryFn: async () => {
+      const params: Record<string, unknown> = { page, size: DEFAULT_PAGE_SIZE, search };
+      if (categoryFilter !== 'all') {
+        params.category = categoryFilter;
+      }
+      const { data } = await api.get<PublicBlogPostPage>('/blog/public/posts', { params });
+      return data;
+    }
+  });
+
+  const totalPages = postsQuery.data?.totalPages ?? 0;
+  const totalElements = postsQuery.data?.totalElements ?? 0;
+  const pageCount = postsQuery.data?.content.length ?? 0;
+  const showingFrom = totalElements === 0 ? 0 : page * DEFAULT_PAGE_SIZE + 1;
+  const showingTo = totalElements === 0 ? 0 : page * DEFAULT_PAGE_SIZE + pageCount;
+
+  const renderExcerpt = (post: PublicBlogPost) => {
+    const plain = stripHtml(post.description);
+    if (plain.length <= 160) {
+      return plain;
+    }
+    return `${plain.slice(0, 157)}…`;
+  };
+
+  const buildMediaUrl = (key?: string | null) => {
+    if (!key) {
+      return null;
+    }
+    const base = api.defaults.baseURL ?? '';
+    return `${base.replace(/\/$/, '')}/blog/media/${key}`;
+  };
+
+  const cards = useMemo(() => postsQuery.data?.content ?? [], [postsQuery.data?.content]);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-10 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary">Insights</p>
+            <h1 className="mt-1 text-3xl font-bold text-slate-900">Latest from the Blog</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-500">
+              Explore product updates, customer stories, and best practices curated by our team.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:w-80">
+            <input
+              type="search"
+              value={searchDraft}
+              onChange={(event) => setSearchDraft(event.target.value)}
+              placeholder="Search articles"
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            />
+            <select
+              value={categoryFilter}
+              onChange={(event) => setCategoryFilter(event.target.value as typeof categoryFilter)}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            >
+              <option value="all">All categories</option>
+              {categoriesQuery.data?.map((category) => (
+                <option key={category.id} value={category.slug}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-6 py-10">
+        <div className="mb-6 flex items-center justify-between text-sm text-slate-500">
+          <span>
+            Showing {showingFrom}-{showingTo} of {totalElements}
+          </span>
+          <span>Page {page + 1} of {Math.max(totalPages, 1)}</span>
+        </div>
+
+        {postsQuery.isLoading && (
+          <div className="rounded-2xl border border-slate-200 bg-white p-10 text-center text-slate-500 shadow-sm">
+            Loading articles…
+          </div>
+        )}
+
+        {!postsQuery.isLoading && cards.length === 0 && (
+          <div className="rounded-2xl border border-slate-200 bg-white p-10 text-center text-slate-500 shadow-sm">
+            No blog posts found. Try adjusting your search.
+          </div>
+        )}
+
+        {!postsQuery.isLoading && cards.length > 0 && (
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {cards.map((post) => {
+              const banner = buildMediaUrl(post.bannerImage) ?? 'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1200&q=80';
+              return (
+                <article
+                  key={post.slug}
+                  className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+                >
+                  <div className="relative h-48 w-full overflow-hidden">
+                    <img src={banner} alt={post.title} className="h-full w-full object-cover" />
+                  </div>
+                  <div className="flex flex-1 flex-col px-5 py-4">
+                    <div className="flex items-center justify-between text-xs text-slate-400">
+                      <span className="font-semibold uppercase tracking-wide text-primary/80">{post.category}</span>
+                      {post.publishedAt && <time dateTime={post.publishedAt}>{new Date(post.publishedAt).toLocaleDateString()}</time>}
+                    </div>
+                    <h2 className="mt-3 text-lg font-semibold text-slate-900">
+                      <Link to={`/blog/${post.slug}`} className="hover:text-primary">
+                        {post.title}
+                      </Link>
+                    </h2>
+                    <p className="mt-2 flex-1 text-sm leading-relaxed text-slate-600">{renderExcerpt(post)}</p>
+                    <div className="mt-4">
+                      <Link
+                        to={`/blog/${post.slug}`}
+                        className="inline-flex items-center text-sm font-semibold text-primary hover:text-blue-600"
+                      >
+                        Read more
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={1.6}
+                          className="ml-1 h-4 w-4"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="m9 5 7 7-7 7" />
+                        </svg>
+                      </Link>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="mt-8 flex items-center justify-between text-sm text-slate-600">
+          <button
+            type="button"
+            onClick={() => setPage((prev) => Math.max(prev - 1, 0))}
+            disabled={page === 0 || postsQuery.isLoading}
+            className="rounded-lg border border-slate-200 px-4 py-2 transition disabled:cursor-not-allowed disabled:opacity-40 hover:border-primary hover:text-primary"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              setPage((prev) =>
+                postsQuery.data && prev < postsQuery.data.totalPages - 1 ? prev + 1 : prev
+              )
+            }
+            disabled={
+              postsQuery.isLoading || (postsQuery.data ? page >= postsQuery.data.totalPages - 1 : true)
+            }
+            className="rounded-lg border border-slate-200 px-4 py-2 transition disabled:cursor-not-allowed disabled:opacity-40 hover:border-primary hover:text-primary"
+          >
+            Next
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default PublicBlogListPage;

--- a/frontend/src/pages/PublicBlogPostPage.tsx
+++ b/frontend/src/pages/PublicBlogPostPage.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useRef } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import api from '../services/http';
+import type { PublicBlogPost } from '../types/blog';
+
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, ' ').trim();
+
+const PublicBlogPostPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+
+  const postQuery = useQuery<PublicBlogPost>({
+    queryKey: ['public', 'blog', 'post', slug],
+    queryFn: async () => {
+      if (!slug) {
+        throw new Error('Missing slug');
+      }
+      const { data } = await api.get<PublicBlogPost>(`/blog/public/posts/${slug}`);
+      return data;
+    },
+    enabled: Boolean(slug)
+  });
+
+  const originalTitleRef = useRef<string>(document.title);
+
+  useEffect(() => {
+    if (postQuery.data?.metaTitle) {
+      document.title = postQuery.data.metaTitle;
+    } else if (postQuery.data?.title) {
+      document.title = `${postQuery.data.title} – Blog`;
+    }
+    return () => {
+      document.title = originalTitleRef.current;
+    };
+  }, [postQuery.data?.metaTitle, postQuery.data?.title]);
+
+  if (postQuery.isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-500">
+        Loading article…
+      </div>
+    );
+  }
+
+  if (postQuery.isError || !postQuery.data) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 px-6">
+        <div className="max-w-lg rounded-2xl border border-slate-200 bg-white p-10 text-center shadow-sm">
+          <h1 className="text-2xl font-semibold text-slate-800">Article not found</h1>
+          <p className="mt-3 text-sm text-slate-500">
+            We couldn't find the story you were looking for. It may have been moved or unpublished.
+          </p>
+          <Link
+            to="/blog"
+            className="mt-6 inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-600"
+          >
+            Back to blog
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const post = postQuery.data;
+  const base = api.defaults.baseURL ?? '';
+  const hero = post.bannerImage
+    ? `${base.replace(/\/$/, '')}/blog/media/${post.bannerImage}`
+    : 'https://images.unsplash.com/photo-1454165205744-3b78555e5572?auto=format&fit=crop&w=1600&q=80';
+  const metaImage = post.metaImage ? `${base.replace(/\/$/, '')}/blog/media/${post.metaImage}` : undefined;
+
+  const metaRef = useRef<HTMLMetaElement | null>(null);
+
+  useEffect(() => {
+    if (!metaImage) {
+      if (metaRef.current) {
+        metaRef.current.remove();
+        metaRef.current = null;
+      }
+      return;
+    }
+    const element = document.createElement('meta');
+    element.setAttribute('property', 'og:image');
+    element.setAttribute('content', metaImage);
+    document.head.appendChild(element);
+    metaRef.current = element;
+    return () => {
+      element.remove();
+      metaRef.current = null;
+    };
+  }, [metaImage]);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="bg-white shadow-sm">
+        <div className="mx-auto max-w-5xl px-6 py-6">
+          <Link to="/blog" className="inline-flex items-center text-sm font-semibold text-primary hover:text-blue-600">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.6}
+              className="mr-1 h-4 w-4"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to all articles
+          </Link>
+          <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-primary/80">{post.category}</p>
+          <h1 className="mt-2 text-4xl font-bold text-slate-900">{post.title}</h1>
+          {post.publishedAt && (
+            <p className="mt-2 text-sm text-slate-500">Published on {new Date(post.publishedAt).toLocaleDateString()}</p>
+          )}
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="mt-6 overflow-hidden rounded-3xl">
+          <img src={hero} alt={post.title} className="h-80 w-full object-cover" />
+        </div>
+        <article className="mx-auto max-w-none py-10">
+          <div
+            className="space-y-4 text-base leading-relaxed text-slate-700"
+            dangerouslySetInnerHTML={{ __html: post.description }}
+          />
+        </article>
+        <aside className="mb-12 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-800">Article metadata</h2>
+          <dl className="mt-4 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+            <div>
+              <dt className="font-medium text-slate-500">Meta title</dt>
+              <dd>{post.metaTitle || post.title}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-slate-500">Meta description</dt>
+              <dd>{post.metaDescription || stripHtml(post.description).slice(0, 160)}</dd>
+            </div>
+            {post.metaKeywords && (
+              <div className="sm:col-span-2">
+                <dt className="font-medium text-slate-500">Keywords</dt>
+                <dd>{post.metaKeywords}</dd>
+              </div>
+            )}
+          </dl>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default PublicBlogPostPage;

--- a/frontend/src/routes/PermissionRoute.tsx
+++ b/frontend/src/routes/PermissionRoute.tsx
@@ -11,7 +11,7 @@ const PermissionRoute = ({ required }: PermissionRouteProps) => {
   const { permissions } = useAppSelector((state) => state.auth);
   const allowed = hasAnyPermission(permissions as PermissionKey[], required);
   if (!allowed) {
-    return <Navigate to="/403" replace />;
+    return <Navigate to="/admin/403" replace />;
   }
   return <Outlet />;
 };

--- a/frontend/src/types/blog.ts
+++ b/frontend/src/types/blog.ts
@@ -1,0 +1,50 @@
+import type { Pagination } from './models';
+
+export interface BlogCategory {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BlogPost {
+  id: number;
+  categoryId: number;
+  categoryName: string;
+  title: string;
+  slug: string;
+  description: string;
+  bannerImage?: string | null;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  metaKeywords?: string | null;
+  metaImage?: string | null;
+  published: boolean;
+  publishedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PublicBlogPost {
+  title: string;
+  slug: string;
+  description: string;
+  bannerImage?: string | null;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  metaKeywords?: string | null;
+  metaImage?: string | null;
+  category: string;
+  publishedAt?: string | null;
+}
+
+export interface BlogMediaUploadResponse {
+  key: string;
+  url: string;
+}
+
+export type BlogCategoryPage = Pagination<BlogCategory>;
+export type BlogPostPage = Pagination<BlogPost>;
+export type PublicBlogPostPage = Pagination<PublicBlogPost>;


### PR DESCRIPTION
## Summary
- introduce blog category and post entities, services, controllers, and media storage with Flyway seeding and public API exposure
- gate blog CRUD endpoints with new permissions while updating security defaults and admin navigation to live under /admin
- add admin pages for managing categories/posts plus public listing and detail routes that share uploaded media assets
- update the Flyway migration to use MySQL-compatible column types so the backend boots successfully on MySQL
- redirect successful logins to the /admin workspace so authenticated users land on the dashboard instead of looping on the login page
- ensure blog post listings load their category relationships within read-only transactions so the table refreshes instead of stalling on "Loading posts…"

## Testing
- mvn -f backend/pom.xml -DskipTests package *(fails: Maven Central returns HTTP 403 while resolving dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e672889c688323be45711293bbc290